### PR TITLE
Add payment and login methods

### DIFF
--- a/src/main/java/com/incognia/AddressType.java
+++ b/src/main/java/com/incognia/AddressType.java
@@ -1,0 +1,7 @@
+package com.incognia;
+
+public enum AddressType {
+  SHIPPING,
+  BILLING,
+  HOME
+}

--- a/src/main/java/com/incognia/PostTransactionRequestBody.java
+++ b/src/main/java/com/incognia/PostTransactionRequestBody.java
@@ -1,0 +1,17 @@
+package com.incognia;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class PostTransactionRequestBody {
+  String installationId;
+  String accountId;
+
+  String type;
+  String externalId;
+  @Builder.Default List<TransactionAddress> addresses = Collections.emptyList();
+}

--- a/src/main/java/com/incognia/TransactionAddress.java
+++ b/src/main/java/com/incognia/TransactionAddress.java
@@ -1,0 +1,13 @@
+package com.incognia;
+
+import lombok.AllArgsConstructor;
+import lombok.Value;
+
+@Value
+@AllArgsConstructor
+public class TransactionAddress {
+  String type;
+  String addressLine;
+  StructuredAddress structuredAddress;
+  Coordinates addressCoordinates;
+}

--- a/src/main/java/com/incognia/TransactionAssessment.java
+++ b/src/main/java/com/incognia/TransactionAssessment.java
@@ -1,0 +1,12 @@
+package com.incognia;
+
+import java.util.Map;
+import java.util.UUID;
+import lombok.Value;
+
+@Value
+public class TransactionAssessment {
+  UUID id;
+  Assessment riskAssessment;
+  Map<String, Object> evidence;
+}

--- a/src/test/java/com/incognia/IncogniaAPITest.java
+++ b/src/test/java/com/incognia/IncogniaAPITest.java
@@ -6,7 +6,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.incognia.fixtures.AddressFixture;
 import com.incognia.fixtures.TokenCreationFixture;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.SneakyThrows;
@@ -137,5 +139,153 @@ class IncogniaAPITest {
     expectedEvidence.put("device_integrity", deviceIntegrity);
 
     assertThat(signupAssessment.getEvidence()).containsExactlyInAnyOrderEntriesOf(expectedEvidence);
+  }
+
+  @Test
+  @DisplayName("should return the expected login transaction response")
+  @SneakyThrows
+  void testRegisterLogin_whenDataIsValid() {
+    String token = TokenCreationFixture.createToken();
+    String installationId = "installation-id";
+    String accountId = "account-id";
+    String externalId = "external-id";
+
+    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(token, CLIENT_ID, CLIENT_SECRET);
+    dispatcher.setExpectedTransactionRequestBody(
+        PostTransactionRequestBody.builder()
+            .installationId(installationId)
+            .externalId(externalId)
+            .accountId(accountId)
+            .type("login")
+            .build());
+    mockServer.setDispatcher(dispatcher);
+    TransactionAssessment transactionAssessment =
+        client.registerLogin(installationId, accountId, externalId);
+    assertTransactionAssessment(transactionAssessment);
+  }
+
+  @Test
+  @DisplayName("should return the expected payment transaction response")
+  @SneakyThrows
+  void testRegisterPayment_whenDataIsValid() {
+    String token = TokenCreationFixture.createToken();
+    String installationId = "installation-id";
+    String accountId = "account-id";
+    String externalId = "external-id";
+    Address address =
+        Address.builder()
+            .structuredAddress(
+                StructuredAddress.builder()
+                    .countryCode("US")
+                    .countryName("United States of America")
+                    .locale("en-US")
+                    .state("NY")
+                    .city("New York City")
+                    .borough("Manhattan")
+                    .neighborhood("Midtown")
+                    .street("W 34th St.")
+                    .number("20")
+                    .complements("Floor 2")
+                    .postalCode("10001")
+                    .build())
+            .coordinates(new Coordinates(40.74836007062138, -73.98509720487937))
+            .build();
+
+    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(token, CLIENT_ID, CLIENT_SECRET);
+    List<TransactionAddress> transactionAddresses =
+        Collections.singletonList(
+            new TransactionAddress(
+                "shipping", null, address.getStructuredAddress(), address.getCoordinates()));
+    dispatcher.setExpectedTransactionRequestBody(
+        PostTransactionRequestBody.builder()
+            .installationId(installationId)
+            .externalId(externalId)
+            .accountId(accountId)
+            .type("payment")
+            .addresses(transactionAddresses)
+            .build());
+    mockServer.setDispatcher(dispatcher);
+    TransactionAssessment transactionAssessment =
+        client.registerPayment(
+            installationId,
+            accountId,
+            externalId,
+            Collections.singletonMap(AddressType.SHIPPING, address));
+    assertTransactionAssessment(transactionAssessment);
+  }
+
+  @Test
+  @DisplayName("should throw illegal argument exception with correct message")
+  @SneakyThrows
+  void testRegisterPayment_whenInstallationIdIsNotValid() {
+    assertThatThrownBy(() -> client.registerPayment(null, "account id"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("'installation id' cannot be empty");
+    assertThatThrownBy(() -> client.registerPayment("", "account id"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("'installation id' cannot be empty");
+  }
+
+  @Test
+  @DisplayName("should throw illegal argument exception with correct message")
+  @SneakyThrows
+  void testRegisterLogin_whenInstallationIdIsNotValid() {
+    assertThatThrownBy(() -> client.registerLogin(null, "account id"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("'installation id' cannot be empty");
+    assertThatThrownBy(() -> client.registerLogin("", "account id"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("'installation id' cannot be empty");
+  }
+
+  @Test
+  @DisplayName("should throw illegal argument exception with correct message")
+  @SneakyThrows
+  void testRegisterPayment_whenAccountIdIsNotValid() {
+    assertThatThrownBy(() -> client.registerPayment("installation id", null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("'account id' cannot be empty");
+    assertThatThrownBy(() -> client.registerPayment("installation id", ""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("'account id' cannot be empty");
+  }
+
+  @Test
+  @DisplayName("should throw illegal argument exception with correct message")
+  @SneakyThrows
+  void testRegisterLogin_whenAccountIdIsNotValid() {
+    assertThatThrownBy(() -> client.registerLogin("installation id", null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("'account id' cannot be empty");
+    assertThatThrownBy(() -> client.registerLogin("installation id", ""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("'account id' cannot be empty");
+  }
+
+  private void assertTransactionAssessment(TransactionAssessment transactionAssessment) {
+    assertThat(transactionAssessment)
+        .extracting("id", "riskAssessment")
+        .containsExactly(
+            UUID.fromString("dfe1f2ff-8f0d-4ce8-aed1-af8435143044"), Assessment.LOW_RISK);
+    Map<String, Object> locationServices = new HashMap<>();
+    locationServices.put("location_permission_enabled", true);
+    locationServices.put("location_sensors_enabled", true);
+    Map<String, Object> deviceIntegrity = new HashMap<>();
+    deviceIntegrity.put("probable_root", false);
+    deviceIntegrity.put("emulator", false);
+    deviceIntegrity.put("gps_spoofing", false);
+    deviceIntegrity.put("from_official_store", true);
+
+    Map<String, Object> expectedEvidence = new HashMap<>();
+    expectedEvidence.put("device_model", "Moto Z2 Play");
+    expectedEvidence.put("device_fraud_reputation", "unknown");
+    expectedEvidence.put("distance_to_trusted_location", 21.06295635345013);
+    expectedEvidence.put("last_location_ts", "2022-11-01T22:45:53.299Z");
+    expectedEvidence.put("sensor_match_type", "gps");
+    expectedEvidence.put("location_events_quantity", 62);
+    expectedEvidence.put("location_services", locationServices);
+    expectedEvidence.put("device_integrity", deviceIntegrity);
+
+    assertThat(transactionAssessment.getEvidence()).containsAllEntriesOf(expectedEvidence);
   }
 }

--- a/src/test/resources/post_transaction_response.json
+++ b/src/test/resources/post_transaction_response.json
@@ -1,0 +1,32 @@
+{
+  "id": "dfe1f2ff-8f0d-4ce8-aed1-af8435143044",
+  "risk_assessment": "low_risk",
+  "evidence": {
+    "device_model": "Moto Z2 Play",
+    "known_account": true,
+    "location_services": {
+      "location_permission_enabled": true,
+      "location_sensors_enabled": true
+    },
+    "device_integrity": {
+      "probable_root": false,
+      "emulator": false,
+      "gps_spoofing": false,
+      "from_official_store": true
+    },
+    "device_fraud_reputation": "unknown",
+    "distance_to_trusted_location": 21.06295635345013,
+    "last_location_ts": "2022-11-01T22:45:53.299Z",
+    "sensor_match_type": "gps",
+    "addresses": [
+      {
+        "type": "shipping",
+        "location_events_near_address": 43,
+        "address_quality": "good",
+        "geocode_quality": "good",
+        "address_match": "street"
+      }
+    ],
+    "location_events_quantity": 62
+  }
+}


### PR DESCRIPTION
This adds payment (registerPayment) and login (registerLogin) methods. They both call the same endpoint, but we want to make this distinction for our clients.

The methods also have overloads for optional parameters (like external id)