### PR TITLE
Add register feedback method

### DIFF
--- a/src/main/java/com/incognia/FeedbackEvent.java
+++ b/src/main/java/com/incognia/FeedbackEvent.java
@@ -1,0 +1,44 @@
+package com.incognia;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum FeedbackEvent {
+  @JsonProperty("payment_accepted")
+  PAYMENT_ACCEPTED,
+  @JsonProperty("payment_declined")
+  PAYMENT_DECLINED,
+  @JsonProperty("payment_declined_by_risk_analysis")
+  PAYMENT_DECLINED_BY_RISK_ANALYSIS,
+  @JsonProperty("payment_declined_by_acquirer")
+  PAYMENT_DECLINED_BY_ACQUIRER,
+  @JsonProperty("payment_declined_by_business")
+  PAYMENT_DECLINED_BY_BUSINESS,
+  @JsonProperty("payment_declined_by_manual_review")
+  PAYMENT_DECLINED_BY_MANUAL_REVIEW,
+  @JsonProperty("login_accepted")
+  LOGIN_ACCEPTED,
+  @JsonProperty("login_declined")
+  LOGIN_DECLINED,
+  @JsonProperty("signup_accepted")
+  SIGNUP_ACCEPTED,
+  @JsonProperty("signup_declined")
+  SIGNUP_DECLINED,
+  @JsonProperty("challenge_passed")
+  CHALLENGE_PASSED,
+  @JsonProperty("challenge_failed")
+  CHALLENGE_FAILED,
+  @JsonProperty("password_changed_successfully")
+  PASSWORD_CHANGED_SUCCESSFULLY,
+  @JsonProperty("password_change_failed")
+  PASSWORD_CHANGE_FAILED,
+  @JsonProperty("verified")
+  VERIFIED,
+  @JsonProperty("not_verified")
+  NOT_VERIFIED,
+  @JsonProperty("chargeback")
+  CHARGEBACK,
+  @JsonProperty("promotion_abuse")
+  PROMOTION_ABUSE,
+  @JsonProperty("account_takeover")
+  ACCOUNT_TAKEOVER;
+}

--- a/src/main/java/com/incognia/FeedbackIdentifiers.java
+++ b/src/main/java/com/incognia/FeedbackIdentifiers.java
@@ -1,0 +1,15 @@
+package com.incognia;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class FeedbackIdentifiers {
+  String installationId;
+  String loginId;
+  String paymentId;
+  String signupId;
+  String accountId;
+  String externalId;
+}

--- a/src/main/java/com/incognia/IncogniaAPI.java
+++ b/src/main/java/com/incognia/IncogniaAPI.java
@@ -1,5 +1,6 @@
 package com.incognia;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -109,6 +110,23 @@ public class IncogniaAPI {
             .build();
     return tokenAwareNetworkingClient.doPost(
         "api/v2/authentication/transactions", requestBody, TransactionAssessment.class);
+  }
+
+  public void registerFeedback(
+      FeedbackEvent feedbackEvent, Instant timestamp, FeedbackIdentifiers identifiers)
+      throws IncogniaException {
+    PostFeedbackRequestBody requestBody =
+        PostFeedbackRequestBody.builder()
+            .event(feedbackEvent)
+            .timestamp(timestamp.toEpochMilli())
+            .installationId(identifiers.getInstallationId())
+            .accountId(identifiers.getAccountId())
+            .loginId(identifiers.getLoginId())
+            .paymentId(identifiers.getPaymentId())
+            .signupId(identifiers.getSignupId())
+            .externalId(identifiers.getExternalId())
+            .build();
+    tokenAwareNetworkingClient.doPost("api/v2/feedbacks", requestBody);
   }
 
   @NotNull

--- a/src/main/java/com/incognia/ObjectMapperFactory.java
+++ b/src/main/java/com/incognia/ObjectMapperFactory.java
@@ -1,9 +1,12 @@
 package com.incognia;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
 public class ObjectMapperFactory {
   static final ObjectMapper OBJECT_MAPPER =
-      new ObjectMapper().setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+      new ObjectMapper()
+          .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+          .setSerializationInclusion(Include.NON_NULL);
 }

--- a/src/main/java/com/incognia/PostFeedbackRequestBody.java
+++ b/src/main/java/com/incognia/PostFeedbackRequestBody.java
@@ -1,0 +1,17 @@
+package com.incognia;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class PostFeedbackRequestBody {
+  FeedbackEvent event;
+  Long timestamp;
+  String accountId;
+  String externalId;
+  String installationId;
+  String paymentId;
+  String loginId;
+  String signupId;
+}

--- a/src/main/java/com/incognia/TokenAwareNetworkingClient.java
+++ b/src/main/java/com/incognia/TokenAwareNetworkingClient.java
@@ -37,6 +37,12 @@ public class TokenAwareNetworkingClient {
         Collections.singletonMap(AUTHORIZATION_HEADER, "Bearer " + token.getToken()));
   }
 
+  public <T> void doPost(String path, T body) throws IncogniaException {
+    refreshTokenIfNeeded();
+    networkingClient.doPost(
+        path, body, Collections.singletonMap(AUTHORIZATION_HEADER, "Bearer " + token.getToken()));
+  }
+
   public <T> T doGet(String path, Class<T> responseType) throws IncogniaException {
     refreshTokenIfNeeded();
     return networkingClient.doGet(

--- a/src/test/java/com/incognia/IncogniaAPITest.java
+++ b/src/test/java/com/incognia/IncogniaAPITest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.incognia.fixtures.AddressFixture;
 import com.incognia.fixtures.TokenCreationFixture;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -212,6 +213,39 @@ class IncogniaAPITest {
             externalId,
             Collections.singletonMap(AddressType.SHIPPING, address));
     assertTransactionAssessment(transactionAssessment);
+  }
+
+  @Test
+  @DisplayName("should be successful")
+  @SneakyThrows
+  void testRegisterFeedback_whenDataIsValid() {
+    String token = TokenCreationFixture.createToken();
+    String installationId = "installation-id";
+    String accountId = "account-id";
+    String externalId = "external-id";
+    String signupId = UUID.randomUUID().toString();
+    Instant timestamp = Instant.now();
+
+    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(token, CLIENT_ID, CLIENT_SECRET);
+    dispatcher.setExpectedFeedbackRequestBody(
+        PostFeedbackRequestBody.builder()
+            .installationId(installationId)
+            .externalId(externalId)
+            .signupId(signupId)
+            .accountId(accountId)
+            .event(FeedbackEvent.ACCOUNT_TAKEOVER)
+            .timestamp(timestamp.toEpochMilli())
+            .build());
+    mockServer.setDispatcher(dispatcher);
+    client.registerFeedback(
+        FeedbackEvent.ACCOUNT_TAKEOVER,
+        timestamp,
+        FeedbackIdentifiers.builder()
+            .installationId(installationId)
+            .accountId(accountId)
+            .externalId(externalId)
+            .signupId(signupId)
+            .build());
   }
 
   @Test

--- a/src/test/java/com/incognia/TokenAwareDispatcher.java
+++ b/src/test/java/com/incognia/TokenAwareDispatcher.java
@@ -24,6 +24,7 @@ public class TokenAwareDispatcher extends Dispatcher {
   @Setter private String expectedAddressLine;
   @Setter private UUID expectedSignupId;
   @Setter private PostTransactionRequestBody expectedTransactionRequestBody;
+  @Setter private PostFeedbackRequestBody expectedFeedbackRequestBody;
   @Getter private int tokenRequestCount;
 
   public TokenAwareDispatcher(String token, String clientId, String clientSecret) {
@@ -59,10 +60,23 @@ public class TokenAwareDispatcher extends Dispatcher {
         && "POST".equals(request.getMethod())) {
       return handlePostTransaction(request);
     }
+    if ("/api/v2/feedbacks".equals(request.getPath()) && "POST".equals(request.getMethod())) {
+      return handlePostFeedback(request);
+    }
     if ("/api/v1/token".equals(request.getPath()) && "POST".equals(request.getMethod())) {
       return handleTokenRequest(request);
     }
     return new MockResponse().setResponseCode(404);
+  }
+
+  @SneakyThrows
+  private MockResponse handlePostFeedback(RecordedRequest request) {
+    assertThat(request.getHeader("Content-Type")).contains("application/json");
+    assertThat(request.getHeader("Authorization")).isEqualTo("Bearer " + token);
+    PostFeedbackRequestBody postFeedbackRequestBody =
+        objectMapper.readValue(request.getBody().inputStream(), PostFeedbackRequestBody.class);
+    assertThat(postFeedbackRequestBody).isEqualTo(expectedFeedbackRequestBody);
+    return new MockResponse().setResponseCode(200);
   }
 
   @SneakyThrows


### PR DESCRIPTION
This adds a method to call the feedback api. Its signature is quite different (it gets an object with optional ids, as there are too many ids).

We also needed some changes in the networking layer, to support post requests that do not return a body