### PR TITLE
Full support for oauth client credentials flow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,10 +28,9 @@ dependencies {
     annotationProcessor "org.projectlombok:lombok:$lombokVersion"
     implementation platform("com.squareup.okhttp3:okhttp-bom:4.9.1")
     implementation "com.squareup.okhttp3:okhttp"
-    implementation "com.squareup.okhttp3:logging-interceptor"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.12.3"
-    implementation 'com.auth0:java-jwt:3.16.0'
 
+    testImplementation 'com.auth0:java-jwt:3.16.0'
     testImplementation 'commons-io:commons-io:2.10.0'
     testImplementation 'org.assertj:assertj-core:3.19.0'
     testImplementation 'org.mockito:mockito-core:3.11.0'

--- a/src/main/java/com/incognia/TokenAwareNetworkingClient.java
+++ b/src/main/java/com/incognia/TokenAwareNetworkingClient.java
@@ -1,12 +1,9 @@
 package com.incognia;
 
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.interfaces.DecodedJWT;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import okhttp3.OkHttpClient;
 
@@ -14,11 +11,13 @@ public class TokenAwareNetworkingClient {
   private static final String TOKEN_PATH = "api/v1/token";
   private static final String AUTHORIZATION_HEADER = "Authorization";
   private static final int TOKEN_REFRESH_BEFORE_SECONDS = 10;
+  private static final String TOKEN_REQUEST_BODY = "grant_type=client_credentials";
 
   private final NetworkingClient networkingClient;
   private final String clientId;
   private final String clientSecret;
-  private DecodedJWT token;
+  private TokenResponse token;
+  private Instant tokenExpiration;
 
   public TokenAwareNetworkingClient(
       OkHttpClient httpClient, String baseUrl, String clientId, String clientSecret) {
@@ -26,6 +25,7 @@ public class TokenAwareNetworkingClient {
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.token = null;
+    this.tokenExpiration = null;
   }
 
   public <T, U> U doPost(String path, T body, Class<U> responseType) throws IncogniaException {
@@ -34,13 +34,13 @@ public class TokenAwareNetworkingClient {
         path,
         body,
         responseType,
-        Collections.singletonMap(AUTHORIZATION_HEADER, "Bearer " + token.getToken()));
+        Collections.singletonMap(AUTHORIZATION_HEADER, buildAuthorizationHeader()));
   }
 
   public <T> void doPost(String path, T body) throws IncogniaException {
     refreshTokenIfNeeded();
     networkingClient.doPost(
-        path, body, Collections.singletonMap(AUTHORIZATION_HEADER, "Bearer " + token.getToken()));
+        path, body, Collections.singletonMap(AUTHORIZATION_HEADER, buildAuthorizationHeader()));
   }
 
   public <T> T doGet(String path, Class<T> responseType) throws IncogniaException {
@@ -48,26 +48,30 @@ public class TokenAwareNetworkingClient {
     return networkingClient.doGet(
         path,
         responseType,
-        Collections.singletonMap(AUTHORIZATION_HEADER, "Bearer " + token.getToken()));
+        Collections.singletonMap(AUTHORIZATION_HEADER, buildAuthorizationHeader()));
+  }
+
+  private String buildAuthorizationHeader() {
+    return token.getTokenType() + " " + token.getAccessToken();
   }
 
   private void refreshTokenIfNeeded() throws IncogniaException {
     if (token == null
-        || Instant.now().until(token.getExpiresAt().toInstant(), ChronoUnit.SECONDS)
+        || Instant.now().until(tokenExpiration, ChronoUnit.SECONDS)
             <= TOKEN_REFRESH_BEFORE_SECONDS) {
       // TODO(rato): handle concurrent requests
       token = getNewToken();
+      tokenExpiration = Instant.now().plusSeconds(token.getExpiresIn());
     }
   }
 
-  private DecodedJWT getNewToken() throws IncogniaException {
-    Map<String, String> headers = new HashMap<>();
-    headers.put("Content-Type", "application/x-www-form-urlencoded");
+  private TokenResponse getNewToken() throws IncogniaException {
     String clientIdSecret = clientId + ":" + clientSecret;
-    headers.put(
-        AUTHORIZATION_HEADER,
-        "Basic " + Base64.getUrlEncoder().encodeToString(clientIdSecret.getBytes()));
-    TokenResponse tokenResponse = networkingClient.doPost(TOKEN_PATH, TokenResponse.class, headers);
-    return JWT.decode(tokenResponse.getAccessToken());
+    Map<String, String> headers =
+        Collections.singletonMap(
+            AUTHORIZATION_HEADER,
+            "Basic " + Base64.getUrlEncoder().encodeToString(clientIdSecret.getBytes()));
+    return networkingClient.doPostFormUrlEncoded(
+        TOKEN_PATH, TOKEN_REQUEST_BODY, TokenResponse.class, headers);
   }
 }

--- a/src/test/java/com/incognia/TokenAwareDispatcher.java
+++ b/src/test/java/com/incognia/TokenAwareDispatcher.java
@@ -13,6 +13,7 @@ import lombok.SneakyThrows;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.apache.commons.io.IOUtils;
 import org.jetbrains.annotations.NotNull;
 
 public class TokenAwareDispatcher extends Dispatcher {
@@ -110,12 +111,14 @@ public class TokenAwareDispatcher extends Dispatcher {
     return new MockResponse().setResponseCode(200).setBody(response);
   }
 
-  @NotNull
+  @SneakyThrows
   private MockResponse handleTokenRequest(@NotNull RecordedRequest request) {
     tokenRequestCount++;
     String authorizationHeader = request.getHeader("Authorization");
     assertThat(authorizationHeader).startsWith("Basic");
     assertThat(request.getHeader("Content-Type")).contains("application/x-www-form-urlencoded");
+    String body = IOUtils.toString(request.getBody().inputStream(), StandardCharsets.UTF_8);
+    assertThat(body).isEqualTo("grant_type=client_credentials");
     String[] idAndSecret =
         new String(
                 Base64.getUrlDecoder().decode(authorizationHeader.split(" ")[1]),


### PR DESCRIPTION

## Proposed changes

- Read expiration from response json instead of decoding token
- Use token type from response json instead of hardcoding 'Bearer'
- Send grant_type=client_credentials in body for token requests

## Checklist
- [x] Style check and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
