### PR TITLE
feat(SignupAssessment, TransactionAssessment): Adds Device Id To Responses

### DIFF
--- a/src/main/java/com/incognia/SignupAssessment.java
+++ b/src/main/java/com/incognia/SignupAssessment.java
@@ -10,4 +10,5 @@ public class SignupAssessment {
   UUID requestId;
   Assessment riskAssessment;
   Map<String, Object> evidence;
+  String deviceId;
 }

--- a/src/main/java/com/incognia/TransactionAssessment.java
+++ b/src/main/java/com/incognia/TransactionAssessment.java
@@ -9,4 +9,5 @@ public class TransactionAssessment {
   UUID id;
   Assessment riskAssessment;
   Map<String, Object> evidence;
+  String deviceId;
 }

--- a/src/test/java/com/incognia/IncogniaAPITest.java
+++ b/src/test/java/com/incognia/IncogniaAPITest.java
@@ -50,11 +50,12 @@ class IncogniaAPITest {
     mockServer.setDispatcher(dispatcher);
     SignupAssessment signupAssessment = client.registerSignup(installationId, address);
     assertThat(signupAssessment)
-        .extracting("id", "requestId", "riskAssessment")
+        .extracting("id", "requestId", "riskAssessment", "deviceId")
         .containsExactly(
             UUID.fromString("5e76a7ca-577c-4f47-a752-9e1e0cee9e49"),
             UUID.fromString("8afc84a7-f1d4-488d-bd69-36d9a37168b7"),
-            Assessment.LOW_RISK);
+            Assessment.LOW_RISK,
+            "1df6d999-556d-42c3-8c63-357e5d08d95b");
     Map<String, Object> locationServices = new HashMap<>();
     locationServices.put("location_permission_enabled", true);
     locationServices.put("location_sensors_enabled", true);
@@ -115,11 +116,12 @@ class IncogniaAPITest {
     mockServer.setDispatcher(dispatcher);
     SignupAssessment signupAssessment = client.getSignupAssessment(signupId);
     assertThat(signupAssessment)
-        .extracting("id", "requestId", "riskAssessment")
+        .extracting("id", "requestId", "riskAssessment", "deviceId")
         .containsExactly(
             UUID.fromString("5e76a7ca-577c-4f47-a752-9e1e0cee9e49"),
             UUID.fromString("8afc84a7-f1d4-488d-bd69-36d9a37168b7"),
-            Assessment.LOW_RISK);
+            Assessment.LOW_RISK,
+            "1df6d999-556d-42c3-8c63-357e5d08d95b");
     Map<String, Object> locationServices = new HashMap<>();
     locationServices.put("location_permission_enabled", true);
     locationServices.put("location_sensors_enabled", true);
@@ -298,9 +300,11 @@ class IncogniaAPITest {
 
   private void assertTransactionAssessment(TransactionAssessment transactionAssessment) {
     assertThat(transactionAssessment)
-        .extracting("id", "riskAssessment")
+        .extracting("id", "riskAssessment", "deviceId")
         .containsExactly(
-            UUID.fromString("dfe1f2ff-8f0d-4ce8-aed1-af8435143044"), Assessment.LOW_RISK);
+            UUID.fromString("dfe1f2ff-8f0d-4ce8-aed1-af8435143044"),
+            Assessment.LOW_RISK,
+            "1df6d999-556d-42c3-8c63-357e5d08d95b");
     Map<String, Object> locationServices = new HashMap<>();
     locationServices.put("location_permission_enabled", true);
     locationServices.put("location_sensors_enabled", true);

--- a/src/test/resources/get_onboarding_response.json
+++ b/src/test/resources/get_onboarding_response.json
@@ -2,6 +2,7 @@
   "id": "5e76a7ca-577c-4f47-a752-9e1e0cee9e49",
   "request_id": "8afc84a7-f1d4-488d-bd69-36d9a37168b7",
   "risk_assessment": "low_risk",
+  "device_id": "1df6d999-556d-42c3-8c63-357e5d08d95b",
   "evidence": {
     "device_model": "Moto Z2 Play",
     "geocode_quality": "good",

--- a/src/test/resources/post_onboarding_response.json
+++ b/src/test/resources/post_onboarding_response.json
@@ -2,6 +2,7 @@
   "id": "5e76a7ca-577c-4f47-a752-9e1e0cee9e49",
   "request_id": "8afc84a7-f1d4-488d-bd69-36d9a37168b7",
   "risk_assessment": "low_risk",
+  "device_id": "1df6d999-556d-42c3-8c63-357e5d08d95b",
   "evidence": {
     "device_model": "Moto Z2 Play",
     "geocode_quality": "good",

--- a/src/test/resources/post_transaction_response.json
+++ b/src/test/resources/post_transaction_response.json
@@ -1,6 +1,7 @@
 {
   "id": "dfe1f2ff-8f0d-4ce8-aed1-af8435143044",
   "risk_assessment": "low_risk",
+  "device_id": "1df6d999-556d-42c3-8c63-357e5d08d95b",
   "evidence": {
     "device_model": "Moto Z2 Play",
     "known_account": true,


### PR DESCRIPTION
## Proposed changes

This PR Adds Device Id to the response of transactions and onboarding routes.

## Checklist
- [X] Style check and tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
