### PR TITLE
chore(dependabot): check for updates once a week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,7 @@ updates:
 - package-ecosystem: gradle
   directory: "/"
   schedule:
-    interval: daily
+    interval: "weekly"
+    day: "monday"
     time: "03:00"
-  open-pull-requests-limit: 3
-  assignees:
-      - "racevedoo"
-  reviewers:
-      - "racevedoo"
+  open-pull-requests-limit: 20


### PR DESCRIPTION
## Proposed changes

Configures dependabot to:
- check for updates once a week
- open at most 20 PRs so it catches more updates at each run
- let GitHub choose assignees and reviewers

## Checklist
- [x] Style check and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
