### PR TITLE
Fix dependency declarations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,9 +81,7 @@ publishing {
     publications {
         mavenJava(MavenPublication) { publication ->
             publication.artifactId = 'incognia-api-client'
-            artifact tasks.jar
-            artifact tasks.javadocJar
-            artifact tasks.sourcesJar
+            from components.java
             pom {
                 name = 'Incognia API Client'
                 description = "Java client library for Incognia's API"


### PR DESCRIPTION
## Proposed changes

Since we removed the shadow config for our lib, dependencies were not being published correctly in the POM file. This fixes it by setting the maven publish plugin to get all java components for publishing (this includes dependencies correctly)
