### PR TITLE
Improve compatibility with older jackson versions

### DIFF
--- a/src/main/java/com/incognia/api/clients/ObjectMapperFactory.java
+++ b/src/main/java/com/incognia/api/clients/ObjectMapperFactory.java
@@ -2,11 +2,14 @@ package com.incognia.api.clients;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 
 public class ObjectMapperFactory {
+  @SuppressWarnings("deprecation")
+  // PropertyNamingStrategy.SNAKE_CASE is deprecated but we use it for compatibility with older
+  // jackson versions
   public static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper()
-          .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+          .setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
           .setSerializationInclusion(Include.NON_NULL);
 }


### PR DESCRIPTION

## Proposed changes

Use PropertyNamingStrategy.SNAKE_CASE instead of PropertyNamingStrategies.SNAKE_CASE for compatibility with older jackson versions


## Checklist
- [x] Style check and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
