### PR TITLE
Fix installation-id parsing on response and additional locations post request

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ And then download the artifact incognia-api-client
 <dependency>
   <groupId>com.incognia</groupId>
   <artifactId>incognia-api-client</artifactId>
-  <version>2.4.0</version>
+  <version>2.4.1</version>
 </dependency>
 ```
 
@@ -39,7 +39,7 @@ repositories {
 And then add the dependency
 ```gradle
 dependencies {
-     implementation 'com.incognia:incognia-api-client:2.4.0'
+     implementation 'com.incognia:incognia-api-client:2.4.1'
 }
 ```
 We support Java 8+.

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "com.incognia"
-version = "2.4.0"
+version = "2.4.1"
 
 task createProjectVersionFile {
     def projectVersionDir = "$projectDir/src/main/java/com/incognia/api"

--- a/src/main/java/com/incognia/api/IncogniaAPI.java
+++ b/src/main/java/com/incognia/api/IncogniaAPI.java
@@ -113,7 +113,8 @@ public class IncogniaAPI {
             request.getAddress().getCoordinates(),
             request.getExternalId(),
             request.getPolicyId(),
-            request.getAccountId());
+            request.getAccountId(),
+            request.getAdditionalLocations());
     return tokenAwareNetworkingClient.doPost(
         "api/v2/onboarding/signups", postSignupRequestBody, SignupAssessment.class);
   }

--- a/src/main/java/com/incognia/onboarding/PostSignupRequestBody.java
+++ b/src/main/java/com/incognia/onboarding/PostSignupRequestBody.java
@@ -1,7 +1,9 @@
 package com.incognia.onboarding;
 
+import com.incognia.common.AdditionalLocation;
 import com.incognia.common.Coordinates;
 import com.incognia.common.StructuredAddress;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -15,4 +17,5 @@ public class PostSignupRequestBody {
   String externalId;
   String policyId;
   String accountId;
+  List<AdditionalLocation> additionalLocations;
 }

--- a/src/main/java/com/incognia/onboarding/SignupAssessment.java
+++ b/src/main/java/com/incognia/onboarding/SignupAssessment.java
@@ -15,4 +15,5 @@ public class SignupAssessment {
   Set<Reason> reasons;
   Map<String, Object> evidence;
   String deviceId;
+  String installationId;
 }

--- a/src/main/java/com/incognia/transaction/TransactionAssessment.java
+++ b/src/main/java/com/incognia/transaction/TransactionAssessment.java
@@ -16,4 +16,5 @@ public class TransactionAssessment {
   List<Reason> reasons;
   Map<String, Object> evidence;
   String deviceId;
+  String installationId;
 }


### PR DESCRIPTION
## Proposed changes

Fix Installation ID Parsing: The PR enhances the parsing of the installation ID within the Post Onboarding and Transaction response.

Expanded Locations Data in Post-Signup Requests: Additionally, it extends the functionality of the PostSignupRequest by adding support for additional locations.
