### PR TITLE
Remove installation id from register web login

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,6 @@ IncogniaAPI api = new IncogniaAPI("client-id", "client-secret");
 try {
      RegisterLoginRequest registerLoginRequest =
         RegisterLoginRequest.builder()
-          .installationId("installation id")
           .accountId("account id")
           .externalId("external id")
           .sessionToken("session-token")

--- a/src/main/java/com/incognia/api/IncogniaAPI.java
+++ b/src/main/java/com/incognia/api/IncogniaAPI.java
@@ -209,7 +209,6 @@ public class IncogniaAPI {
    * IncogniaAPI api = new IncogniaAPI("client-id", "client-secret", Region.BR);
    * try {
    *     RegisterLoginRequest loginRequest = RegisterLoginRequest.builder()
-   *         .installationId("installation-id")
    *         .accountId("account-id")
    *         .externalId("external-id")
    *         .sessionToken("session-token")
@@ -232,12 +231,10 @@ public class IncogniaAPI {
   public TransactionAssessment registerWebLogin(RegisterWebLoginRequest request)
       throws IncogniaException {
     Asserts.assertNotNull(request, "register login request");
-    Asserts.assertNotEmpty(request.getInstallationId(), "installation id");
     Asserts.assertNotEmpty(request.getAccountId(), "account id");
     Asserts.assertNotEmpty(request.getSessionToken(), "session token");
     PostTransactionRequestBody requestBody =
         PostTransactionRequestBody.builder()
-            .installationId(request.getInstallationId())
             .accountId(request.getAccountId())
             .externalId(request.getExternalId())
             .sessionToken(request.getSessionToken())

--- a/src/main/java/com/incognia/transaction/login/RegisterWebLoginRequest.java
+++ b/src/main/java/com/incognia/transaction/login/RegisterWebLoginRequest.java
@@ -8,7 +8,6 @@ import lombok.Value;
 @Value
 @Builder
 public class RegisterWebLoginRequest {
-  String installationId;
   String accountId;
   String externalId;
   String sessionToken;

--- a/src/test/java/com/incognia/api/IncogniaAPITest.java
+++ b/src/test/java/com/incognia/api/IncogniaAPITest.java
@@ -227,7 +227,6 @@ class IncogniaAPITest {
   @SneakyThrows
   void testRegisterWebLogin_whenDataIsValid(Boolean eval) {
     String token = TokenCreationFixture.createToken();
-    String installationId = "installation-id";
     String accountId = "account-id";
     String externalId = "external-id";
     String sessionToken = "session-token";
@@ -235,7 +234,6 @@ class IncogniaAPITest {
     TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(token, CLIENT_ID, CLIENT_SECRET);
     dispatcher.setExpectedTransactionRequestBody(
         PostTransactionRequestBody.builder()
-            .installationId(installationId)
             .externalId(externalId)
             .accountId(accountId)
             .type("login")
@@ -246,7 +244,6 @@ class IncogniaAPITest {
     mockServer.setDispatcher(dispatcher);
     RegisterWebLoginRequest loginRequest =
         RegisterWebLoginRequest.builder()
-            .installationId(installationId)
             .accountId(accountId)
             .externalId(externalId)
             .evaluateTransaction(eval)


### PR DESCRIPTION
## Proposed changes

As seen [here](https://dash.incognia.com/accounts-test/sandbox/api-reference#tag/Transactions/operation/transactions-post) for web, the installation id is not part of the request, since the sessionToken already has this data.

## Checklist
- [x] Style check and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
