### PR TITLE
Adding policyId to Payment API. Plus minor documentation updates and code organization

### DIFF
--- a/src/main/java/com/incognia/api/IncogniaAPI.java
+++ b/src/main/java/com/incognia/api/IncogniaAPI.java
@@ -108,16 +108,16 @@ public class IncogniaAPI {
     Asserts.assertNotEmpty(request.getInstallationId(), "installation id");
     Asserts.assertNotNull(request.getAddress(), "address");
     PostSignupRequestBody postSignupRequestBody =
-        new PostSignupRequestBody(
-            request.getInstallationId(),
-            null,
-            request.getAddress().getAddressLine(),
-            request.getAddress().getStructuredAddress(),
-            request.getAddress().getCoordinates(),
-            request.getExternalId(),
-            request.getPolicyId(),
-            request.getAccountId(),
-            request.getAdditionalLocations());
+        PostSignupRequestBody.builder()
+            .installationId(request.getInstallationId())
+            .addressLine(request.getAddress().getAddressLine())
+            .structuredAddress(request.getAddress().getStructuredAddress())
+            .addressCoordinates(request.getAddress().getCoordinates())
+            .externalId(request.getExternalId())
+            .policyId(request.getPolicyId())
+            .accountId(request.getAccountId())
+            .additionalLocations(request.getAdditionalLocations())
+            .build();
     return tokenAwareNetworkingClient.doPost(
         "api/v2/onboarding/signups", postSignupRequestBody, SignupAssessment.class);
   }
@@ -162,6 +162,7 @@ public class IncogniaAPI {
    *         .installationId("installation-id")
    *         .accountId("account-id")
    *         .externalId("external-id")
+   *         .policyId("policy-id")
    *         .evaluateTransaction(true) // can be omitted as it uses true as the default value
    *         .build();
    *      TransactionAssessment assessment = api.registerLogin(loginRequest);
@@ -215,6 +216,7 @@ public class IncogniaAPI {
    *         .accountId("account-id")
    *         .externalId("external-id")
    *         .sessionToken("session-token")
+   *         .policyId("policy-id")
    *         .evaluateTransaction(true) // can be omitted as it uses true as the default value
    *         .build();
    *      TransactionAssessment assessment = api.registerLogin(loginRequest);
@@ -342,6 +344,7 @@ public class IncogniaAPI {
    *              .installationId( "installation-id")
    *              .accountId("account-id")
    *              .externalId("external-id")
+   *              .policyId("policy-id")
    *              .addresses(addresses)
    *              .evaluateTransaction(true) // can be omitted as it uses true as the default value
    *              .paymentValue(PaymentValue.builder().currency("BRL").amount(10.0).build())
@@ -373,6 +376,7 @@ public class IncogniaAPI {
             .installationId(request.getInstallationId())
             .accountId(request.getAccountId())
             .externalId(request.getExternalId())
+            .policyId(request.getPolicyId())
             .type("payment")
             .addresses(transactionAddresses)
             .paymentValue(request.getPaymentValue())

--- a/src/main/java/com/incognia/transaction/payment/RegisterPaymentRequest.java
+++ b/src/main/java/com/incognia/transaction/payment/RegisterPaymentRequest.java
@@ -16,6 +16,7 @@ public class RegisterPaymentRequest {
   String installationId;
   String accountId;
   String externalId;
+  String policyId;
   @Builder.Default Map<AddressType, Address> addresses = Collections.emptyMap();
   @Builder.Default List<PaymentMethod> paymentMethods = Collections.emptyList();
   PaymentValue paymentValue;

--- a/src/test/java/com/incognia/api/IncogniaAPITest.java
+++ b/src/test/java/com/incognia/api/IncogniaAPITest.java
@@ -377,6 +377,7 @@ class IncogniaAPITest {
     String installationId = "installation-id";
     String accountId = "account-id";
     String externalId = "external-id";
+    String policyId = "policy-id";
     Address address =
         Address.builder()
             .structuredAddress(
@@ -419,6 +420,7 @@ class IncogniaAPITest {
             .installationId(installationId)
             .accountId(accountId)
             .externalId(externalId)
+            .policyId(policyId)
             .addresses(Collections.singletonMap(AddressType.SHIPPING, address))
             .evaluateTransaction(eval)
             .paymentValue(paymentValue)
@@ -428,6 +430,7 @@ class IncogniaAPITest {
         PostTransactionRequestBody.builder()
             .installationId(installationId)
             .externalId(externalId)
+            .policyId(policyId)
             .accountId(accountId)
             .type("payment")
             .addresses(transactionAddresses)
@@ -447,6 +450,7 @@ class IncogniaAPITest {
     String installationId = "installation-id";
     String accountId = "account-id";
     String externalId = "external-id";
+    String policyId = "policy-id";
     Address address =
         Address.builder()
             .structuredAddress(
@@ -489,6 +493,7 @@ class IncogniaAPITest {
         PostTransactionRequestBody.builder()
             .installationId(installationId)
             .externalId(externalId)
+            .policyId(policyId)
             .accountId(accountId)
             .type("payment")
             .addresses(transactionAddresses)
@@ -501,6 +506,7 @@ class IncogniaAPITest {
             .installationId(installationId)
             .accountId(accountId)
             .externalId(externalId)
+            .policyId(policyId)
             .addresses(Collections.singletonMap(AddressType.SHIPPING, address))
             .evaluateTransaction(false)
             .paymentValue(paymentValue)


### PR DESCRIPTION
## Proposed changes

For a time we are moving towards having policies for every type of transaction-org we have. We already implemented policies for login and sign up here. This PR brings policies to Payment as well.

## Further comments

Plus, this PR also brings minor changes and code organization missed on previous ones.

## Checklist
- [x] Style check and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
