### PR TITLE
Do not fail to deserialize response json when unknown fields are introduced

### DIFF
--- a/src/main/java/com/incognia/api/clients/ObjectMapperFactory.java
+++ b/src/main/java/com/incognia/api/clients/ObjectMapperFactory.java
@@ -1,6 +1,7 @@
 package com.incognia.api.clients;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 
@@ -11,5 +12,6 @@ public class ObjectMapperFactory {
   public static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper()
           .setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
-          .setSerializationInclusion(Include.NON_NULL);
+          .setSerializationInclusion(Include.NON_NULL)
+          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 }


### PR DESCRIPTION
## Proposed changes

We should not break json deserialization if a unknown field is introduced in the API response



## Checklist
- [x] Style check and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
