### PR TITLE
Support null address in RegisterSignupRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ And then download the artifact incognia-api-client
 <dependency>
   <groupId>com.incognia</groupId>
   <artifactId>incognia-api-client</artifactId>
-  <version>2.6.2</version>
+  <version>2.7.0</version>
 </dependency>
 ```
 
@@ -39,7 +39,7 @@ repositories {
 And then add the dependency
 ```gradle
 dependencies {
-     implementation 'com.incognia:incognia-api-client:2.6.2'
+     implementation 'com.incognia:incognia-api-client:2.7.0'
 }
 ```
 We support Java 8+.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,22 @@ try {
 }
 ```
 
+It's also possible to register a signup without an address:
+
+```java
+IncogniaAPI api = new IncogniaAPI("client-id", "client-secret");
+try {
+    RegisterSignupRequest signupRequest = RegisterSignupRequest.builder()
+        .installationId("installation id")
+        .build();
+     SignupAssessment assessment = api.registerSignup(signupRequest);
+} catch (IncogniaAPIException e) {
+     //Some api error happened (invalid data, invalid credentials)
+} catch (IncogniaException e) {
+     //Something unexpected happened
+}
+```
+
 #### Getting a Signup
 
 This method allows you to query the latest assessment for a given signup event, returning a `SignupAssessment`, containing the risk assessment and supporting evidence:

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "com.incognia"
-version = "2.6.2"
+version = "2.7.0"
 
 task createProjectVersionFile {
     def projectVersionDir = "$projectDir/src/main/java/com/incognia/api"

--- a/src/main/java/com/incognia/api/IncogniaAPI.java
+++ b/src/main/java/com/incognia/api/IncogniaAPI.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import okhttp3.OkHttpClient;
@@ -106,13 +107,13 @@ public class IncogniaAPI {
   public SignupAssessment registerSignup(RegisterSignupRequest request) throws IncogniaException {
     Asserts.assertNotNull(request, "register signup request");
     Asserts.assertNotEmpty(request.getInstallationId(), "installation id");
-    Asserts.assertNotNull(request.getAddress(), "address");
+    Optional<Address> address = Optional.ofNullable(request.getAddress());
     PostSignupRequestBody postSignupRequestBody =
         PostSignupRequestBody.builder()
             .installationId(request.getInstallationId())
-            .addressLine(request.getAddress().getAddressLine())
-            .structuredAddress(request.getAddress().getStructuredAddress())
-            .addressCoordinates(request.getAddress().getCoordinates())
+            .addressLine(address.map(Address::getAddressLine).orElse(null))
+            .structuredAddress(address.map(Address::getStructuredAddress).orElse(null))
+            .addressCoordinates(address.map(Address::getCoordinates).orElse(null))
             .externalId(request.getExternalId())
             .policyId(request.getPolicyId())
             .accountId(request.getAccountId())

--- a/src/main/java/com/incognia/onboarding/RegisterSignupRequest.java
+++ b/src/main/java/com/incognia/onboarding/RegisterSignupRequest.java
@@ -5,12 +5,13 @@ import com.incognia.common.Address;
 import java.util.List;
 import lombok.Builder;
 import lombok.Value;
+import org.jetbrains.annotations.Nullable;
 
 @Value
 @Builder
 public class RegisterSignupRequest {
   String installationId;
-  Address address;
+  @Nullable Address address;
   String externalId;
   String policyId;
   String accountId;

--- a/src/test/java/com/incognia/api/IncogniaAPITest.java
+++ b/src/test/java/com/incognia/api/IncogniaAPITest.java
@@ -128,6 +128,62 @@ class IncogniaAPITest {
   }
 
   @Test
+  @DisplayName("should return the expected signup response")
+  @SneakyThrows
+  void testRegisterSignup_withEmptyAddress() {
+    String token = TokenCreationFixture.createToken();
+    String installationId = "installation-id";
+    String accountId = "my-account";
+    String policyId = UUID.randomUUID().toString();
+    String externalId = "external-id";
+
+    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(token, CLIENT_ID, CLIENT_SECRET);
+    dispatcher.setExpectedAddressLine(null);
+    dispatcher.setExpectedInstallationId(installationId);
+    dispatcher.setExpectedExternalId(externalId);
+    dispatcher.setExpectedPolicyId(policyId);
+    dispatcher.setExpectedAccountId(accountId);
+    mockServer.setDispatcher(dispatcher);
+    RegisterSignupRequest registerSignupRequest =
+        RegisterSignupRequest.builder()
+            .installationId(installationId)
+            .accountId(accountId)
+            .policyId(policyId)
+            .externalId(externalId)
+            .build();
+    SignupAssessment signupAssessment = client.registerSignup(registerSignupRequest);
+    assertThat(signupAssessment)
+        .extracting("id", "requestId", "riskAssessment", "deviceId")
+        .containsExactly(
+            UUID.fromString("5e76a7ca-577c-4f47-a752-9e1e0cee9e49"),
+            UUID.fromString("8afc84a7-f1d4-488d-bd69-36d9a37168b7"),
+            Assessment.HIGH_RISK,
+            "1df6d999-556d-42c3-8c63-357e5d08d95b");
+    Map<String, Object> locationServices = new HashMap<>();
+    locationServices.put("location_permission_enabled", true);
+    locationServices.put("location_sensors_enabled", true);
+    Map<String, Object> deviceIntegrity = new HashMap<>();
+    deviceIntegrity.put("probable_root", true);
+    deviceIntegrity.put("emulator", false);
+    deviceIntegrity.put("gps_spoofing", false);
+    deviceIntegrity.put("from_official_store", true);
+
+    Map<String, Object> expectedEvidence = new HashMap<>();
+    expectedEvidence.put("device_model", "Moto Z2 Play");
+    expectedEvidence.put("location_services", locationServices);
+    expectedEvidence.put("device_integrity", deviceIntegrity);
+
+    assertThat(signupAssessment.getEvidence()).containsExactlyInAnyOrderEntriesOf(expectedEvidence);
+
+    Reason expectedReason =
+        Reason.builder()
+            .code(ReasonCode.DEVICE_INTEGRITY.getCode())
+            .source(ReasonSource.LOCAL.getSource())
+            .build();
+    assertThat(signupAssessment.getReasons()).containsExactly(expectedReason);
+  }
+
+  @Test
   @DisplayName("should return the expected web signup response")
   @SneakyThrows
   void testRegisterWebSignup_whenDataIsValid() {

--- a/src/test/java/com/incognia/api/IncogniaAPITest.java
+++ b/src/test/java/com/incognia/api/IncogniaAPITest.java
@@ -128,7 +128,7 @@ class IncogniaAPITest {
   }
 
   @Test
-  @DisplayName("should return the expected signup response")
+  @DisplayName("should return the expected signup response when the address is empty")
   @SneakyThrows
   void testRegisterSignup_withEmptyAddress() {
     String token = TokenCreationFixture.createToken();

--- a/src/test/java/com/incognia/api/clients/TokenAwareDispatcher.java
+++ b/src/test/java/com/incognia/api/clients/TokenAwareDispatcher.java
@@ -149,7 +149,12 @@ public class TokenAwareDispatcher extends Dispatcher {
     assertThat(postSignupRequestBody.getExternalId()).isEqualTo(expectedExternalId);
     assertThat(postSignupRequestBody.getPolicyId()).isEqualTo(expectedPolicyId);
     assertThat(postSignupRequestBody.getAddressLine()).isEqualTo(expectedAddressLine);
-    String response = ResourceUtils.getResourceFileAsString("post_onboarding_response.json");
+    String response =
+        ResourceUtils.getResourceFileAsString(
+            postSignupRequestBody.getAddressLine() != null
+                    || postSignupRequestBody.getSessionToken() != null
+                ? "post_onboarding_response.json"
+                : "post_onboarding_response_no_address.json");
     return new MockResponse().setResponseCode(200).setBody(response);
   }
 

--- a/src/test/resources/post_onboarding_response_no_address.json
+++ b/src/test/resources/post_onboarding_response_no_address.json
@@ -1,0 +1,25 @@
+{
+  "id": "5e76a7ca-577c-4f47-a752-9e1e0cee9e49",
+  "request_id": "8afc84a7-f1d4-488d-bd69-36d9a37168b7",
+  "risk_assessment": "high_risk",
+  "device_id": "1df6d999-556d-42c3-8c63-357e5d08d95b",
+  "reasons": [
+    {
+      "code": "device_integrity",
+      "source": "local"
+    }
+  ],
+  "evidence": {
+    "device_model": "Moto Z2 Play",
+    "location_services": {
+      "location_permission_enabled": true,
+      "location_sensors_enabled": true
+    },
+    "device_integrity": {
+      "probable_root": true,
+      "emulator": false,
+      "gps_spoofing": false,
+      "from_official_store": true
+    }
+  }
+}


### PR DESCRIPTION
## Proposed changes

In our onboarding api, address is optional. In this lib, it was required.

This makes address nullable and adds proper testing


## Checklist
- [x] Style check and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
