### PR TITLE
Add shaded jar artifact along with regular jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Java lightweight client library for [Incognia APIs](https://dash.incognia.com/ap
 
 ## Installation
 
-Incognia API Java Client is available on Maven Central.
+Incognia API Java Client is available on Maven Central. We provide 2 artifact ids: `incognia-api-client` and `incognia-api-client-shaded`.
+`incognia-api-client-shaded` includes all of our dependencies shaded into a single jar, so you don't need to worry about dependency conflicts.
 
 ### Maven
 Add our maven repository
@@ -17,12 +18,20 @@ Add our maven repository
 </repository>
 ```
 
-And then download the artifact incognia-api-client
+And then add the artifact `incognia-api-client` **or** `incognia-api-client-shaded` as a dependency:
+
 ```xml
 <dependency>
   <groupId>com.incognia</groupId>
   <artifactId>incognia-api-client</artifactId>
-  <version>2.7.0</version>
+  <version>2.7.1</version>
+</dependency>
+```
+```xml
+<dependency>
+  <groupId>com.incognia</groupId>
+  <artifactId>incognia-api-client-shaded</artifactId>
+  <version>2.7.1</version>
 </dependency>
 ```
 
@@ -39,9 +48,16 @@ repositories {
 And then add the dependency
 ```gradle
 dependencies {
-     implementation 'com.incognia:incognia-api-client:2.7.0'
+     implementation 'com.incognia:incognia-api-client:2.7.1'
 }
 ```
+OR
+```gradle
+dependencies {
+     implementation 'com.incognia:incognia-api-client-shaded:2.7.1'
+}
+```
+
 We support Java 8+.
 
 ## Usage

--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,11 @@ plugins {
     id 'signing'
     id 'com.diffplug.spotless' version '6.11.0'
     id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
+    id 'io.github.goooler.shadow' version '8.1.7'
 }
 
 group = "com.incognia"
-version = "2.7.0"
+version = "2.7.1"
 
 task createProjectVersionFile {
     def projectVersionDir = "$projectDir/src/main/java/com/incognia/api"
@@ -73,15 +74,30 @@ spotless {
     }
 }
 
+shadowJar {
+    archiveClassifier.set('')
+    relocate 'okhttp3', 'incognia.shadow.okhttp3'
+    relocate 'com.fasterxml', 'incognia.shadow.com.fasterxml'
+    relocate 'com.auth0', 'incognia.shadow.com.auth0'
+}
+
 tasks.named('test') {
     useJUnitPlatform()
 }
+def isShadow = project.findProperty("shadow") == "true"
 
 publishing {
     publications {
         mavenJava(MavenPublication) { publication ->
-            publication.artifactId = 'incognia-api-client'
-            from components.java
+            if (isShadow) {
+                publication.artifactId = 'incognia-api-client-shaded'
+                artifact shadowJar
+            } else {
+                publication.artifactId = 'incognia-api-client'
+                artifact jar
+            }
+            artifact sourcesJar
+            artifact javadocJar
             pom {
                 name = 'Incognia API Client'
                 description = "Java client library for Incognia's API"
@@ -117,3 +133,6 @@ publishing {
     }
 }
 
+tasks.withType(PublishToMavenLocal) {
+    dependsOn jar
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Proposed changes

This adds a new artifact, `incognia-api-client-shaded`, published along with `incognia-api-client`. This new artifact shades dependencies to avoid dependency conflicts with commonly used libraries (jackson, okhttp).


## Checklist
- [x] Style check and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
