### PR TITLE
Add custom properties to post transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ And then add the artifact `incognia-api-client` **or** `incognia-api-client-shad
 <dependency>
   <groupId>com.incognia</groupId>
   <artifactId>incognia-api-client</artifactId>
-  <version>2.7.1</version>
+  <version>2.8.0</version>
 </dependency>
 ```
 ```xml
 <dependency>
   <groupId>com.incognia</groupId>
   <artifactId>incognia-api-client-shaded</artifactId>
-  <version>2.7.1</version>
+  <version>2.8.0</version>
 </dependency>
 ```
 
@@ -48,13 +48,13 @@ repositories {
 And then add the dependency
 ```gradle
 dependencies {
-     implementation 'com.incognia:incognia-api-client:2.7.1'
+     implementation 'com.incognia:incognia-api-client:2.8.0'
 }
 ```
 OR
 ```gradle
 dependencies {
-     implementation 'com.incognia:incognia-api-client-shaded:2.7.1'
+     implementation 'com.incognia:incognia-api-client-shaded:2.8.0'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ try {
           .accountId("account id")
           .externalId("external id")
           .evaluateTransaction(true) // can be omitted as it uses true as the default value
+          .customProperties(Map.of(
+            "custom-property-key", "custom-property-value",
+            "custom-double-property-key", 1.0))
           .build();
      TransactionAssessment assessment = api.registerLogin(registerLoginRequest);
 } catch (IncogniaAPIException e) {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.incognia"
-version = "2.7.1"
+version = "2.8.0"
 
 task createProjectVersionFile {
     def projectVersionDir = "$projectDir/src/main/java/com/incognia/api"

--- a/src/main/java/com/incognia/api/IncogniaAPI.java
+++ b/src/main/java/com/incognia/api/IncogniaAPI.java
@@ -191,6 +191,7 @@ public class IncogniaAPI {
             .accountId(request.getAccountId())
             .externalId(request.getExternalId())
             .policyId(request.getPolicyId())
+            .customProperties(request.getCustomProperties())
             .type("login")
             .build();
 

--- a/src/main/java/com/incognia/transaction/PostTransactionRequestBody.java
+++ b/src/main/java/com/incognia/transaction/PostTransactionRequestBody.java
@@ -5,6 +5,7 @@ import com.incognia.transaction.payment.PaymentMethod;
 import com.incognia.transaction.payment.PaymentValue;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import lombok.Builder;
 import lombok.Value;
 
@@ -28,4 +29,8 @@ public class PostTransactionRequestBody {
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   @Builder.Default
   List<PaymentMethod> paymentMethods = Collections.emptyList();
+
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  @Builder.Default
+  Map<String, Object> customProperties = Collections.emptyMap();
 }

--- a/src/main/java/com/incognia/transaction/login/RegisterLoginRequest.java
+++ b/src/main/java/com/incognia/transaction/login/RegisterLoginRequest.java
@@ -1,5 +1,6 @@
 package com.incognia.transaction.login;
 
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +13,7 @@ public class RegisterLoginRequest {
   String accountId;
   String externalId;
   String policyId;
+  Map<String, Object> customProperties;
 
   @Getter(AccessLevel.NONE)
   Boolean evaluateTransaction;

--- a/src/test/java/com/incognia/api/IncogniaAPITest.java
+++ b/src/test/java/com/incognia/api/IncogniaAPITest.java
@@ -339,6 +339,7 @@ class IncogniaAPITest {
             .addresses(null)
             .paymentMethods(null)
             .policyId(policyId)
+            .customProperties(null)
             .build());
     mockServer.setDispatcher(dispatcher);
     RegisterLoginRequest loginRequest =
@@ -375,6 +376,7 @@ class IncogniaAPITest {
             .addresses(null)
             .paymentMethods(null)
             .policyId(policyId)
+            .customProperties(null)
             .build());
     mockServer.setDispatcher(dispatcher);
     RegisterWebLoginRequest loginRequest =
@@ -409,6 +411,7 @@ class IncogniaAPITest {
             .addresses(null)
             .paymentMethods(null)
             .policyId(policyId)
+            .customProperties(null)
             .build());
     mockServer.setDispatcher(dispatcher);
     RegisterLoginRequest loginRequest =
@@ -492,6 +495,7 @@ class IncogniaAPITest {
             .addresses(transactionAddresses)
             .paymentValue(paymentValue)
             .paymentMethods(paymentMethods)
+            .customProperties(null)
             .build());
     mockServer.setDispatcher(dispatcher);
     TransactionAssessment transactionAssessment = client.registerPayment(paymentRequest);
@@ -555,6 +559,7 @@ class IncogniaAPITest {
             .addresses(transactionAddresses)
             .paymentMethods(paymentMethods)
             .paymentValue(paymentValue)
+            .customProperties(null)
             .build());
     mockServer.setDispatcher(dispatcher);
     RegisterPaymentRequest paymentRequest =

--- a/src/test/java/com/incognia/api/IncogniaAPITest.java
+++ b/src/test/java/com/incognia/api/IncogniaAPITest.java
@@ -339,7 +339,7 @@ class IncogniaAPITest {
             .addresses(null)
             .paymentMethods(null)
             .policyId(policyId)
-            .customProperties(null)
+            .customProperties(Map.of("custom-property", "custom-value"))
             .build());
     mockServer.setDispatcher(dispatcher);
     RegisterLoginRequest loginRequest =
@@ -349,6 +349,7 @@ class IncogniaAPITest {
             .externalId(externalId)
             .evaluateTransaction(eval)
             .policyId(policyId)
+            .customProperties(Map.of("custom-property", "custom-value"))
             .build();
     TransactionAssessment transactionAssessment = client.registerLogin(loginRequest);
     assertTransactionAssessment(transactionAssessment);

--- a/src/test/java/com/incognia/api/IncogniaAPITest.java
+++ b/src/test/java/com/incognia/api/IncogniaAPITest.java
@@ -328,6 +328,8 @@ class IncogniaAPITest {
     String accountId = "account-id";
     String externalId = "external-id";
     String policyId = "policy-id";
+    Map<String, Object> map = new HashMap<>();
+    map.put("custom-property", "custom-value");
 
     TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(token, CLIENT_ID, CLIENT_SECRET);
     dispatcher.setExpectedTransactionRequestBody(
@@ -339,7 +341,7 @@ class IncogniaAPITest {
             .addresses(null)
             .paymentMethods(null)
             .policyId(policyId)
-            .customProperties(Map.of("custom-property", "custom-value"))
+            .customProperties(map)
             .build());
     mockServer.setDispatcher(dispatcher);
     RegisterLoginRequest loginRequest =
@@ -349,7 +351,7 @@ class IncogniaAPITest {
             .externalId(externalId)
             .evaluateTransaction(eval)
             .policyId(policyId)
-            .customProperties(Map.of("custom-property", "custom-value"))
+            .customProperties(map)
             .build();
     TransactionAssessment transactionAssessment = client.registerLogin(loginRequest);
     assertTransactionAssessment(transactionAssessment);


### PR DESCRIPTION
## Proposed changes

I want to add custom_properties to transactions to support related_account_id.

## Checklist
- [x] Style check and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
