### PR TITLE
Add appVersion and deviceOs to request body for mobile Login/SignUp/Payment risk assessments

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ And then add the artifact `incognia-api-client` **or** `incognia-api-client-shad
 <dependency>
   <groupId>com.incognia</groupId>
   <artifactId>incognia-api-client</artifactId>
-  <version>3.1.0</version>
+  <version>3.2.0</version>
 </dependency>
 ```
 ```xml
 <dependency>
   <groupId>com.incognia</groupId>
   <artifactId>incognia-api-client-shaded</artifactId>
-  <version>3.1.0</version>
+  <version>3.2.0</version>
 </dependency>
 ```
 
@@ -47,13 +47,13 @@ repositories {
 And then add the dependency
 ```gradle
 dependencies {
-     implementation 'com.incognia:incognia-api-client:3.1.0'
+     implementation 'com.incognia:incognia-api-client:3.2.0'
 }
 ```
 OR
 ```gradle
 dependencies {
-     implementation 'com.incognia:incognia-api-client-shaded:3.1.0'
+     implementation 'com.incognia:incognia-api-client-shaded:3.2.0'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.incognia"
-version = "3.1.0"
+version = "3.2.0"
 
 task createProjectVersionFile {
     def projectVersionDir = "$projectDir/src/main/java/com/incognia/api"

--- a/src/main/java/com/incognia/api/IncogniaAPI.java
+++ b/src/main/java/com/incognia/api/IncogniaAPI.java
@@ -142,6 +142,9 @@ public class IncogniaAPI {
         PostSignupRequestBody.builder()
             .installationId(request.getInstallationId())
             .requestToken(request.getRequestToken())
+            .appVersion(request.getAppVersion())
+            .deviceOs(
+                Optional.ofNullable(request.getDeviceOs()).map(String::toLowerCase).orElse(null))
             .addressLine(address.map(Address::getAddressLine).orElse(null))
             .structuredAddress(address.map(Address::getStructuredAddress).orElse(null))
             .addressCoordinates(address.map(Address::getCoordinates).orElse(null))
@@ -195,6 +198,9 @@ public class IncogniaAPI {
         PostTransactionRequestBody.builder()
             .installationId(request.getInstallationId())
             .requestToken(request.getRequestToken())
+            .appVersion(request.getAppVersion())
+            .deviceOs(
+                Optional.ofNullable(request.getDeviceOs()).map(String::toLowerCase).orElse(null))
             .accountId(request.getAccountId())
             .externalId(request.getExternalId())
             .policyId(request.getPolicyId())
@@ -392,6 +398,9 @@ public class IncogniaAPI {
         PostTransactionRequestBody.builder()
             .installationId(request.getInstallationId())
             .requestToken(request.getRequestToken())
+            .appVersion(request.getAppVersion())
+            .deviceOs(
+                Optional.ofNullable(request.getDeviceOs()).map(String::toLowerCase).orElse(null))
             .accountId(request.getAccountId())
             .externalId(request.getExternalId())
             .policyId(request.getPolicyId())

--- a/src/main/java/com/incognia/onboarding/PostSignupRequestBody.java
+++ b/src/main/java/com/incognia/onboarding/PostSignupRequestBody.java
@@ -19,6 +19,8 @@ public class PostSignupRequestBody {
   String sessionToken;
   String requestToken;
   String addressLine;
+  String appVersion;
+  String deviceOs;
   StructuredAddress structuredAddress;
   Coordinates addressCoordinates;
   String externalId;

--- a/src/main/java/com/incognia/onboarding/RegisterSignupRequest.java
+++ b/src/main/java/com/incognia/onboarding/RegisterSignupRequest.java
@@ -13,6 +13,8 @@ import org.jetbrains.annotations.Nullable;
 public class RegisterSignupRequest {
   String installationId;
   String requestToken;
+  String appVersion;
+  String deviceOs;
   @Nullable Address address;
   String externalId;
   String policyId;

--- a/src/main/java/com/incognia/transaction/PostTransactionRequestBody.java
+++ b/src/main/java/com/incognia/transaction/PostTransactionRequestBody.java
@@ -14,6 +14,8 @@ import lombok.Value;
 public class PostTransactionRequestBody {
   String installationId;
   String requestToken;
+  String appVersion;
+  String deviceOs;
   String accountId;
   String sessionToken;
   String policyId;

--- a/src/main/java/com/incognia/transaction/login/RegisterLoginRequest.java
+++ b/src/main/java/com/incognia/transaction/login/RegisterLoginRequest.java
@@ -14,6 +14,8 @@ public class RegisterLoginRequest {
   String accountId;
   String externalId;
   String policyId;
+  String appVersion;
+  String deviceOs;
   Map<String, Object> customProperties;
 
   @Getter(AccessLevel.NONE)

--- a/src/main/java/com/incognia/transaction/payment/RegisterPaymentRequest.java
+++ b/src/main/java/com/incognia/transaction/payment/RegisterPaymentRequest.java
@@ -15,6 +15,8 @@ import lombok.Value;
 public class RegisterPaymentRequest {
   String installationId;
   String requestToken;
+  String appVersion;
+  String deviceOs;
   String accountId;
   String externalId;
   String policyId;

--- a/src/test/java/com/incognia/api/IncogniaAPITest.java
+++ b/src/test/java/com/incognia/api/IncogniaAPITest.java
@@ -154,6 +154,8 @@ class IncogniaAPITest {
     String accountId = "my-account";
     String policyId = UUID.randomUUID().toString();
     String externalId = "external-id";
+    String appVersion = "1.4.3";
+    String deviceOs = "iOS";
 
     TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(token, CLIENT_ID, CLIENT_SECRET);
     dispatcher.setExpectedAddressLine(null);
@@ -161,6 +163,8 @@ class IncogniaAPITest {
     dispatcher.setExpectedExternalId(externalId);
     dispatcher.setExpectedPolicyId(policyId);
     dispatcher.setExpectedAccountId(accountId);
+    dispatcher.setExpectedAppVersion(appVersion);
+    dispatcher.setExpectedDeviceOs(deviceOs.toLowerCase());
     dispatcher.setExpectedCustomProperties(null);
     mockServer.setDispatcher(dispatcher);
     RegisterSignupRequest registerSignupRequest =
@@ -169,6 +173,8 @@ class IncogniaAPITest {
             .accountId(accountId)
             .policyId(policyId)
             .externalId(externalId)
+            .appVersion(appVersion)
+            .deviceOs(deviceOs)
             .customProperties(null)
             .build();
     SignupAssessment signupAssessment = client.registerSignup(registerSignupRequest);
@@ -301,6 +307,8 @@ class IncogniaAPITest {
     String token = TokenCreationFixture.createToken();
     String requestToken = "request-token";
     String accountId = "account-id";
+    String appVersion = "1.4.3";
+    String deviceOs = "Android";
     String externalId = "external-id";
     String policyId = "policy-id";
     Map<String, Object> map = new HashMap<>();
@@ -311,6 +319,8 @@ class IncogniaAPITest {
         PostTransactionRequestBody.builder()
             .requestToken(requestToken)
             .externalId(externalId)
+            .appVersion(appVersion)
+            .deviceOs(deviceOs.toLowerCase())
             .accountId(accountId)
             .type("login")
             .addresses(null)
@@ -323,6 +333,8 @@ class IncogniaAPITest {
         RegisterLoginRequest.builder()
             .requestToken(requestToken)
             .accountId(accountId)
+            .appVersion(appVersion)
+            .deviceOs(deviceOs)
             .externalId(externalId)
             .evaluateTransaction(eval)
             .policyId(policyId)
@@ -413,6 +425,8 @@ class IncogniaAPITest {
     String token = TokenCreationFixture.createToken();
     String requestToken = "request-token";
     String accountId = "account-id";
+    String appVersion = "appVersion";
+    String deviceOs = "iOS";
     String externalId = "external-id";
     String policyId = "policy-id";
     Address address =
@@ -456,6 +470,8 @@ class IncogniaAPITest {
         RegisterPaymentRequest.builder()
             .requestToken(requestToken)
             .accountId(accountId)
+            .appVersion(appVersion)
+            .deviceOs(deviceOs)
             .externalId(externalId)
             .policyId(policyId)
             .addresses(Collections.singletonMap(AddressType.SHIPPING, address))
@@ -469,6 +485,8 @@ class IncogniaAPITest {
             .externalId(externalId)
             .policyId(policyId)
             .accountId(accountId)
+            .appVersion(appVersion)
+            .deviceOs(deviceOs.toLowerCase())
             .type("payment")
             .addresses(transactionAddresses)
             .paymentValue(paymentValue)

--- a/src/test/java/com/incognia/api/clients/TokenAwareDispatcher.java
+++ b/src/test/java/com/incognia/api/clients/TokenAwareDispatcher.java
@@ -36,6 +36,8 @@ public class TokenAwareDispatcher extends Dispatcher {
   @Setter private String expectedInstallationId;
   @Setter private String expectedExternalId;
   @Setter private String expectedAccountId;
+  @Setter private String expectedAppVersion;
+  @Setter private String expectedDeviceOs;
   @Setter private String expectedPolicyId;
   @Setter private String expectedAddressLine;
   @Setter private Map<String, Object> expectedCustomProperties;
@@ -138,6 +140,8 @@ public class TokenAwareDispatcher extends Dispatcher {
     assertThat(postSignupRequestBody.getInstallationId()).isEqualTo(expectedInstallationId);
     assertThat(postSignupRequestBody.getRequestToken()).isEqualTo(expectedRequestToken);
     assertThat(postSignupRequestBody.getAccountId()).isEqualTo(expectedAccountId);
+    assertThat(postSignupRequestBody.getAppVersion()).isEqualTo(expectedAppVersion);
+    assertThat(postSignupRequestBody.getDeviceOs()).isEqualTo(expectedDeviceOs);
     assertThat(postSignupRequestBody.getExternalId()).isEqualTo(expectedExternalId);
     assertThat(postSignupRequestBody.getPolicyId()).isEqualTo(expectedPolicyId);
     assertThat(postSignupRequestBody.getAddressLine()).isEqualTo(expectedAddressLine);


### PR DESCRIPTION
## Proposed changes

We are adding deviceOs and appVersion as an optional field to our Login, SignUp and Payment mobile endpoints

## Checklist
- [x] Style check and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
