### PR TITLE
Adding configurable timeout for clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ And then add the artifact `incognia-api-client` **or** `incognia-api-client-shad
 <dependency>
   <groupId>com.incognia</groupId>
   <artifactId>incognia-api-client</artifactId>
-  <version>3.3.0</version>
+  <version>3.4.0</version>
 </dependency>
 ```
 ```xml
 <dependency>
   <groupId>com.incognia</groupId>
   <artifactId>incognia-api-client-shaded</artifactId>
-  <version>3.3.0</version>
+  <version>3.4.0</version>
 </dependency>
 ```
 
@@ -47,13 +47,13 @@ repositories {
 And then add the dependency
 ```gradle
 dependencies {
-     implementation 'com.incognia:incognia-api-client:3.3.0'
+     implementation 'com.incognia:incognia-api-client:3.4.0'
 }
 ```
 OR
 ```gradle
 dependencies {
-     implementation 'com.incognia:incognia-api-client-shaded:3.3.0'
+     implementation 'com.incognia:incognia-api-client-shaded:3.4.0'
 }
 ```
 
@@ -70,6 +70,19 @@ IncogniaAPI api = IncogniaAPI.init("your-client-id", "your-client-secret");
 ```
 
 This will create a singleton instance of the IncogniaAPI class, which will handle token renewal automatically. You should reuse this instance throughout your application.
+
+The library also allow the users to configure the call timeout themselves. This will give them more control over the expected time response. This can be done by calling the init passing the CustomOptions object as a parameter.
+
+
+```java
+IncogniaAPI api = IncogniaAPI.init(
+    "your-client-id",
+    "your-client-secret",
+    CustomOptions.builder().timeoutMillis(2000).build()
+);
+```
+
+If no parameter is passed the library will use the default timeout of 10 seconds.
 
 After calling `init`, you can get the singleton instance simply calling `IncogniaAPI.instance()`.
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.incognia"
-version = "3.3.0"
+version = "3.4.0"
 
 task createProjectVersionFile {
     def projectVersionDir = "$projectDir/src/main/java/com/incognia/api"

--- a/src/main/java/com/incognia/api/clients/NetworkingClient.java
+++ b/src/main/java/com/incognia/api/clients/NetworkingClient.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.type.MapType;
 import com.incognia.common.exceptions.IncogniaAPIException;
 import com.incognia.common.exceptions.IncogniaException;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -56,8 +57,9 @@ public class NetworkingClient {
     Request request = buildPostRequest(path, body, headers, queryParameters);
     try (Response response = httpClient.newCall(request).execute()) {
       return parseResponse(response, responseType);
+    } catch (InterruptedIOException e) {
+      throw new IncogniaException("network call timeout", e);
     } catch (IOException e) {
-      // TODO(rato): handle timeout
       throw new IncogniaException("network call failed", e);
     }
   }
@@ -74,8 +76,9 @@ public class NetworkingClient {
             .build();
     try (Response response = httpClient.newCall(request).execute()) {
       return parseResponse(response, responseType);
+    } catch (InterruptedIOException e) {
+      throw new IncogniaException("network call timeout", e);
     } catch (IOException e) {
-      // TODO(rato): handle timeout
       throw new IncogniaException("network call failed", e);
     }
   }
@@ -86,8 +89,9 @@ public class NetworkingClient {
     Request request = buildPostRequest(path, body, headers, queryParameters);
     try {
       httpClient.newCall(request).execute().close();
+    } catch (InterruptedIOException e) {
+      throw new IncogniaException("network call timeout", e);
     } catch (IOException e) {
-      // TODO(rato): handle timeout
       throw new IncogniaException("network call failed", e);
     }
   }

--- a/src/main/java/com/incognia/common/utils/CustomOptions.java
+++ b/src/main/java/com/incognia/common/utils/CustomOptions.java
@@ -1,0 +1,10 @@
+package com.incognia.common.utils;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class CustomOptions {
+  Long timeoutMillis;
+}


### PR DESCRIPTION
## Proposed changes

This PR introduces configurable timeout for the Incognia API. If no timeout is set, the library will continue to follow the OKHttp default that is 10 seconds.

## Checklist
- [x] Style check and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
