### PR TITLE
Add Connection Pool Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ And then add the artifact `incognia-api-client` **or** `incognia-api-client-shad
 <dependency>
   <groupId>com.incognia</groupId>
   <artifactId>incognia-api-client</artifactId>
-  <version>3.4.0</version>
+  <version>3.6.0</version>
 </dependency>
 ```
 ```xml
 <dependency>
   <groupId>com.incognia</groupId>
   <artifactId>incognia-api-client-shaded</artifactId>
-  <version>3.4.0</version>
+  <version>3.6.0</version>
 </dependency>
 ```
 
@@ -47,13 +47,13 @@ repositories {
 And then add the dependency
 ```gradle
 dependencies {
-     implementation 'com.incognia:incognia-api-client:3.4.0'
+     implementation 'com.incognia:incognia-api-client:3.6.0'
 }
 ```
 OR
 ```gradle
 dependencies {
-     implementation 'com.incognia:incognia-api-client-shaded:3.4.0'
+     implementation 'com.incognia:incognia-api-client-shaded:3.6.0'
 }
 ```
 
@@ -78,11 +78,15 @@ The library also allow the users to configure the call timeout themselves. This 
 IncogniaAPI api = IncogniaAPI.init(
     "your-client-id",
     "your-client-secret",
-    CustomOptions.builder().timeoutMillis(2000L).build()
+    CustomOptions.builder()
+    .timeoutMillis(2000L)
+    .keepAliveSeconds(3000)
+    .maxConnections(5)
+    .build()
 );
 ```
 
-If no parameter is passed the library will use the default timeout of 10 seconds.
+If no parameter is passed the library will use the default timeout of 10 seconds, 5 minutes of keep alive and 5 max connections.
 
 After calling `init`, you can get the singleton instance simply calling `IncogniaAPI.instance()`.
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,9 @@ dependencies {
     testImplementation 'com.auth0:java-jwt:4.4.0'
     testImplementation 'commons-io:commons-io:2.16.1'
     testImplementation 'org.assertj:assertj-core:3.26.0'
-    testImplementation 'org.mockito:mockito-core:5.12.0'
-    testImplementation 'org.mockito:mockito-junit-jupiter:5.12.0'
+    testImplementation 'org.mockito:mockito-core:4.11.0'
+    testImplementation 'org.mockito:mockito-inline:4.11.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:4.11.0'
     testImplementation "com.squareup.okhttp3:mockwebserver"
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.2"

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.incognia"
-version = "3.4.0"
+version = "3.6.0"
 
 task createProjectVersionFile {
     def projectVersionDir = "$projectDir/src/main/java/com/incognia/api"

--- a/src/main/java/com/incognia/api/clients/NetworkingClient.java
+++ b/src/main/java/com/incognia/api/clients/NetworkingClient.java
@@ -87,8 +87,8 @@ public class NetworkingClient {
       String path, T body, Map<String, String> headers, Map<String, String> queryParameters)
       throws IncogniaException {
     Request request = buildPostRequest(path, body, headers, queryParameters);
-    try {
-      httpClient.newCall(request).execute().close();
+    try (Response ignored = httpClient.newCall(request).execute()) {
+      // No operations performed on response
     } catch (InterruptedIOException e) {
       throw new IncogniaException("network call timeout", e);
     } catch (IOException e) {
@@ -101,8 +101,8 @@ public class NetworkingClient {
       String path, T body, Map<String, String> headers, Map<String, String> queryParameters)
       throws IncogniaException {
     HttpUrl.Builder urlBuilder = baseUrl.newBuilder().addPathSegments(path);
-    for (String parameter : queryParameters.keySet()) {
-      urlBuilder.addQueryParameter(parameter, queryParameters.get(parameter));
+    for (Map.Entry<String, String> entry : queryParameters.entrySet()) {
+      urlBuilder.addQueryParameter(entry.getKey(), entry.getValue());
     }
     Builder requestBuilder = new Builder().url(urlBuilder.build());
     RequestBody requestBody;

--- a/src/main/java/com/incognia/api/clients/TokenAwareNetworkingClient.java
+++ b/src/main/java/com/incognia/api/clients/TokenAwareNetworkingClient.java
@@ -1,6 +1,7 @@
 package com.incognia.api.clients;
 
 import com.incognia.common.exceptions.IncogniaException;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
@@ -100,7 +101,9 @@ public class TokenAwareNetworkingClient {
     Map<String, String> headers =
         Collections.singletonMap(
             AUTHORIZATION_HEADER,
-            "Basic " + Base64.getUrlEncoder().encodeToString(clientIdSecret.getBytes()));
+            "Basic "
+                + Base64.getUrlEncoder()
+                    .encodeToString(clientIdSecret.getBytes(StandardCharsets.UTF_8)));
     return networkingClient.doPostFormUrlEncoded(
         TOKEN_PATH, TOKEN_REQUEST_BODY, TokenResponse.class, headers);
   }

--- a/src/main/java/com/incognia/common/utils/CustomOptions.java
+++ b/src/main/java/com/incognia/common/utils/CustomOptions.java
@@ -6,5 +6,7 @@ import lombok.Value;
 @Value
 @Builder
 public class CustomOptions {
-  Long timeoutMillis;
+  @Builder.Default long timeoutMillis = 10000L;
+  @Builder.Default int maxConnections = 5;
+  @Builder.Default long keepAliveSeconds = 300;
 }


### PR DESCRIPTION
## Proposed changes

Adds connection pool configuration so we are able to set something other than OkHTTP default config.
Had to downgrade Mockito since version 5 is for Java >= 11 and the project is targeting Java 8 and also has GHA using Java 8, so Mockito 4 is the last version to support Java 8.

For `CustomOptions` instead of using `Optional.ofNullable` used Lombok to set the defaults and used primitives so nulls are not allowed. The defaults there, `timeoutMillis` is what we had before, `maxConnections` and `keepAliveSeconds` is what OkHTTP sets by default so we keep what was being set before the addition of those options.

Removed immediate execution of optional orElse.

Made OkHTTP client execute use try with resources so we are sure that the response is always closed.

Removed one map key iteration and later value fetch doing two calls to the map to iterate through the entry set and remove the extra call to the map.

Added the UTF8 charset when using getBytes, so we don't rely on default encoding (which can change)

## Checklist
- [X] Style check and tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
