### PR TITLE
Make Access Token thread safe/aware

### DIFF
--- a/src/main/java/com/incognia/api/clients/NetworkingClient.java
+++ b/src/main/java/com/incognia/api/clients/NetworkingClient.java
@@ -38,10 +38,6 @@ public class NetworkingClient {
         objectMapper.getTypeFactory().constructMapType(HashMap.class, String.class, Object.class);
   }
 
-  public <T, U> U doPost(String path, T body, Class<U> responseType) throws IncogniaException {
-    return doPost(path, body, responseType, Collections.emptyMap(), Collections.emptyMap());
-  }
-
   public <T, U> U doPost(String path, T body, Class<U> responseType, Map<String, String> headers)
       throws IncogniaException {
     return doPost(path, body, responseType, headers, Collections.emptyMap());
@@ -88,7 +84,6 @@ public class NetworkingClient {
       throws IncogniaException {
     Request request = buildPostRequest(path, body, headers, queryParameters);
     try (Response ignored = httpClient.newCall(request).execute()) {
-      // No operations performed on response
     } catch (InterruptedIOException e) {
       throw new IncogniaException("network call timeout", e);
     } catch (IOException e) {

--- a/src/main/java/com/incognia/api/clients/TokenAwareNetworkingClient.java
+++ b/src/main/java/com/incognia/api/clients/TokenAwareNetworkingClient.java
@@ -1,59 +1,52 @@
 package com.incognia.api.clients;
 
 import com.incognia.common.exceptions.IncogniaException;
-import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Base64;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import okhttp3.OkHttpClient;
 
 public class TokenAwareNetworkingClient {
-  private static final String TOKEN_PATH = "api/v2/token";
   private static final String USER_AGENT_HEADER = "User-Agent";
-  private static final String USER_AGENT_HEADER_CONTENT = buildUserAgentHeader();
   private static final String AUTHORIZATION_HEADER = "Authorization";
-  private static final int TOKEN_REFRESH_BEFORE_SECONDS = 10;
-  private static final String TOKEN_REQUEST_BODY = "grant_type=client_credentials";
+  private static final String USER_AGENT_HEADER_CONTENT =
+      String.format(
+          "incognia-api-java/%s (%s %s %s) Java/%s",
+          com.incognia.api.ProjectVersion.PROJECT_VERSION,
+          System.getProperty("os.name"),
+          System.getProperty("os.version"),
+          System.getProperty("os.arch"),
+          System.getProperty("java.version"));
 
   private final NetworkingClient networkingClient;
-  private final String clientId;
-  private final String clientSecret;
-  private TokenResponse token;
-  private Instant tokenExpiration;
+  private final TokenProvider tokenProvider;
 
   public TokenAwareNetworkingClient(
       OkHttpClient httpClient, String baseUrl, String clientId, String clientSecret) {
     this.networkingClient = new NetworkingClient(httpClient, baseUrl);
-    this.clientId = clientId;
-    this.clientSecret = clientSecret;
-    this.token = null;
-    this.tokenExpiration = null;
+    this.tokenProvider = new TokenProvider(clientId, clientSecret, networkingClient);
   }
 
   public <T, U> U doPost(
       String path, T body, Class<U> responseType, Map<String, String> queryParameters)
       throws IncogniaException {
-    refreshTokenIfNeeded();
+    tokenProvider.getToken();
     Map<String, String> headers =
         new HashMap<String, String>() {
           {
             put(USER_AGENT_HEADER, USER_AGENT_HEADER_CONTENT);
-            put(AUTHORIZATION_HEADER, buildAuthorizationHeader());
+            put(AUTHORIZATION_HEADER, tokenProvider.buildAuthorizationHeader());
           }
         };
     return networkingClient.doPost(path, body, responseType, headers, queryParameters);
   }
 
   public <T, U> U doPost(String path, T body, Class<U> responseType) throws IncogniaException {
-    refreshTokenIfNeeded();
+    tokenProvider.getToken();
     Map<String, String> headers =
         new HashMap<String, String>() {
           {
             put(USER_AGENT_HEADER, USER_AGENT_HEADER_CONTENT);
-            put(AUTHORIZATION_HEADER, buildAuthorizationHeader());
+            put(AUTHORIZATION_HEADER, tokenProvider.buildAuthorizationHeader());
           }
         };
     return networkingClient.doPost(path, body, responseType, headers);
@@ -61,50 +54,14 @@ public class TokenAwareNetworkingClient {
 
   public <T> void doPost(String path, T body, Map<String, String> queryParameters)
       throws IncogniaException {
-    refreshTokenIfNeeded();
+    tokenProvider.getToken();
     Map<String, String> headers =
         new HashMap<String, String>() {
           {
             put(USER_AGENT_HEADER, USER_AGENT_HEADER_CONTENT);
-            put(AUTHORIZATION_HEADER, buildAuthorizationHeader());
+            put(AUTHORIZATION_HEADER, tokenProvider.buildAuthorizationHeader());
           }
         };
     networkingClient.doPost(path, body, headers, queryParameters);
-  }
-
-  private String buildAuthorizationHeader() {
-    return token.getTokenType() + " " + token.getAccessToken();
-  }
-
-  private static String buildUserAgentHeader() {
-    return String.format(
-        "incognia-api-java/%s (%s %s %s) Java/%s",
-        com.incognia.api.ProjectVersion.PROJECT_VERSION,
-        System.getProperty("os.name"),
-        System.getProperty("os.version"),
-        System.getProperty("os.arch"),
-        System.getProperty("java.version"));
-  }
-
-  private void refreshTokenIfNeeded() throws IncogniaException {
-    if (token == null
-        || Instant.now().until(tokenExpiration, ChronoUnit.SECONDS)
-            <= TOKEN_REFRESH_BEFORE_SECONDS) {
-      // TODO(rato): handle concurrent requests
-      token = getNewToken();
-      tokenExpiration = Instant.now().plusSeconds(token.getExpiresIn());
-    }
-  }
-
-  private TokenResponse getNewToken() throws IncogniaException {
-    String clientIdSecret = clientId + ":" + clientSecret;
-    Map<String, String> headers =
-        Collections.singletonMap(
-            AUTHORIZATION_HEADER,
-            "Basic "
-                + Base64.getUrlEncoder()
-                    .encodeToString(clientIdSecret.getBytes(StandardCharsets.UTF_8)));
-    return networkingClient.doPostFormUrlEncoded(
-        TOKEN_PATH, TOKEN_REQUEST_BODY, TokenResponse.class, headers);
   }
 }

--- a/src/main/java/com/incognia/api/clients/TokenProvider.java
+++ b/src/main/java/com/incognia/api/clients/TokenProvider.java
@@ -1,0 +1,74 @@
+package com.incognia.api.clients;
+
+import com.incognia.common.exceptions.IncogniaException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
+
+class TokenProvider {
+  private static final int TOKEN_REFRESH_BEFORE_SECONDS = 10;
+  private static final String TOKEN_REQUEST_BODY = "grant_type=client_credentials";
+  private static final String TOKEN_PATH = "api/v2/token";
+
+  private static final ReentrantLock lock = new ReentrantLock();
+  private volatile TokenResponse token;
+
+  private final String clientId;
+  private final String clientSecret;
+  private final NetworkingClient networkingClient;
+
+  public TokenProvider(String clientId, String clientSecret, NetworkingClient networkingClient) {
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
+    this.networkingClient = networkingClient;
+  }
+
+  public TokenResponse getToken() throws IncogniaException {
+    refreshTokenIfNeeded();
+    return token;
+  }
+
+  public String buildAuthorizationHeader() throws IncogniaException {
+    if (token == null) {
+      refreshTokenIfNeeded();
+    }
+
+    return token.getTokenType() + " " + token.getAccessToken();
+  }
+
+  private boolean needsRefresh() {
+    return token == null
+        || Instant.now().until(token.getExpiresAt(), ChronoUnit.SECONDS)
+            <= TOKEN_REFRESH_BEFORE_SECONDS;
+  }
+
+  private void refreshTokenIfNeeded() throws IncogniaException {
+    if (needsRefresh()) {
+      lock.lock();
+      try {
+        if (needsRefresh()) {
+          token = getNewToken();
+          token.computeExpiresAt();
+        }
+      } finally {
+        lock.unlock();
+      }
+    }
+  }
+
+  private TokenResponse getNewToken() throws IncogniaException {
+    String clientIdSecret = clientId + ":" + clientSecret;
+    Map<String, String> headers =
+        Collections.singletonMap(
+            "Authorization",
+            "Basic "
+                + Base64.getUrlEncoder()
+                    .encodeToString(clientIdSecret.getBytes(StandardCharsets.UTF_8)));
+    return networkingClient.doPostFormUrlEncoded(
+        TOKEN_PATH, TOKEN_REQUEST_BODY, TokenResponse.class, headers);
+  }
+}

--- a/src/main/java/com/incognia/api/clients/TokenResponse.java
+++ b/src/main/java/com/incognia/api/clients/TokenResponse.java
@@ -1,5 +1,6 @@
 package com.incognia.api.clients;
 
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -9,4 +10,9 @@ public class TokenResponse {
   private String accessToken;
   private long expiresIn;
   private String tokenType;
+  private Instant expiresAt;
+
+  public void computeExpiresAt() {
+    this.expiresAt = Instant.now().plusSeconds(this.expiresIn);
+  }
 }

--- a/src/test/java/com/incognia/api/IncogniaAPITest.java
+++ b/src/test/java/com/incognia/api/IncogniaAPITest.java
@@ -23,7 +23,6 @@ import com.incognia.feedback.FeedbackEvent;
 import com.incognia.feedback.FeedbackIdentifiers;
 import com.incognia.feedback.PostFeedbackRequestBody;
 import com.incognia.fixtures.AddressFixture;
-import com.incognia.fixtures.TokenCreationFixture;
 import com.incognia.onboarding.RegisterSignupRequest;
 import com.incognia.onboarding.RegisterWebSignupRequest;
 import com.incognia.onboarding.SignupAssessment;
@@ -63,8 +62,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedConstruction;
 
 class IncogniaAPITest {
-  private static final String CLIENT_ID = "client-id";
-  private static final String CLIENT_SECRET = "client-secret";
+  private final String CLIENT_ID = "client-id";
+  private final String CLIENT_SECRET = "client-secret";
+  private final TokenAwareDispatcher dispatcher =
+      new TokenAwareDispatcher(CLIENT_ID, CLIENT_SECRET);
   private MockWebServer mockServer;
   private IncogniaAPI client;
   private IncogniaAPI clientWithLowTimeout;
@@ -181,7 +182,6 @@ class IncogniaAPITest {
   @DisplayName("should return the expected signup response")
   @SneakyThrows
   void testRegisterSignup_whenDataIsValid() {
-    String token = TokenCreationFixture.createToken();
     String requestToken = "request-token";
     String accountId = "my-account";
     String policyId = UUID.randomUUID().toString();
@@ -190,7 +190,6 @@ class IncogniaAPITest {
     Map<String, Object> map = new HashMap<>();
     map.put("custom-property", "custom-value");
 
-    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(token, CLIENT_ID, CLIENT_SECRET);
     dispatcher.setExpectedAddressLine(address.getAddressLine());
     dispatcher.setExpectedRequestToken(requestToken);
     dispatcher.setExpectedExternalId(externalId);
@@ -248,7 +247,6 @@ class IncogniaAPITest {
   @DisplayName("should return the expected signup response when the address is empty")
   @SneakyThrows
   void testRegisterSignup_withEmptyAddress() {
-    String token = TokenCreationFixture.createToken();
     String requestToken = "request-token";
     String accountId = "my-account";
     String policyId = UUID.randomUUID().toString();
@@ -256,7 +254,6 @@ class IncogniaAPITest {
     String appVersion = "1.4.3";
     String deviceOs = "iOS";
 
-    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(token, CLIENT_ID, CLIENT_SECRET);
     dispatcher.setExpectedAddressLine(null);
     dispatcher.setExpectedRequestToken(requestToken);
     dispatcher.setExpectedExternalId(externalId);
@@ -312,13 +309,11 @@ class IncogniaAPITest {
   @DisplayName("should return the expected web signup response")
   @SneakyThrows
   void testRegisterWebSignup_whenDataIsValid() {
-    String token = TokenCreationFixture.createToken();
     String requestToken = "request-token-web-signup";
     String accountId = "my-account";
     String policyId = UUID.randomUUID().toString();
     String externalId = "external-id";
 
-    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(token, CLIENT_ID, CLIENT_SECRET);
     dispatcher.setExpectedRequestToken(requestToken);
     dispatcher.setExpectedExternalId(externalId);
     dispatcher.setExpectedPolicyId(policyId);
@@ -375,12 +370,10 @@ class IncogniaAPITest {
   @DisplayName("should return IncogniaException if exceeds timeout")
   @SneakyThrows
   void testRegisterLogin_whenReachesTheTimeout(Boolean eval) {
-    String token = TokenCreationFixture.createToken();
     String requestToken = "request-token";
     String accountId = "account-id";
     String policyId = "policy-id";
 
-    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(token, CLIENT_ID, CLIENT_SECRET);
     dispatcher.setExpectedTransactionRequestBody(
         PostTransactionRequestBody.builder()
             .requestToken(requestToken)
@@ -409,7 +402,6 @@ class IncogniaAPITest {
   @DisplayName("should return the expected login transaction response")
   @SneakyThrows
   void testRegisterLogin_whenDataIsValid(Boolean eval) {
-    String token = TokenCreationFixture.createToken();
     String requestToken = "request-token";
     String accountId = "account-id";
     String appVersion = "1.4.3";
@@ -425,7 +417,6 @@ class IncogniaAPITest {
     Map<String, Object> map = new HashMap<>();
     map.put("custom-property", "custom-value");
 
-    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(token, CLIENT_ID, CLIENT_SECRET);
     dispatcher.setExpectedTransactionRequestBody(
         PostTransactionRequestBody.builder()
             .requestToken(requestToken)
@@ -463,13 +454,11 @@ class IncogniaAPITest {
   @DisplayName("should return the expected web login transaction response")
   @SneakyThrows
   void testRegisterWebLogin_whenDataIsValid(Boolean eval) {
-    String token = TokenCreationFixture.createToken();
     String accountId = "account-id";
     String externalId = "external-id";
     String requestToken = "request-token";
     String policyId = "policy-id";
 
-    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(token, CLIENT_ID, CLIENT_SECRET);
     dispatcher.setExpectedTransactionRequestBody(
         PostTransactionRequestBody.builder()
             .externalId(externalId)
@@ -498,13 +487,11 @@ class IncogniaAPITest {
   @DisplayName("should return an empty response")
   @SneakyThrows
   void testRegisterLogin_whenEvalIsFalse() {
-    String token = TokenCreationFixture.createToken();
     String requestToken = "request-token";
     String accountId = "account-id";
     String externalId = "external-id";
     String policyId = "policy-id";
 
-    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(token, CLIENT_ID, CLIENT_SECRET);
     dispatcher.setExpectedTransactionRequestBody(
         PostTransactionRequestBody.builder()
             .requestToken(requestToken)
@@ -535,7 +522,6 @@ class IncogniaAPITest {
   @DisplayName("should return the expected payment transaction response")
   @SneakyThrows
   void testRegisterPayment_whenDataIsValid(Boolean eval) {
-    String token = TokenCreationFixture.createToken();
     String requestToken = "request-token";
     String accountId = "account-id";
     String appVersion = "appVersion";
@@ -574,7 +560,6 @@ class IncogniaAPITest {
             .build());
     PaymentValue paymentValue = PaymentValue.builder().amount(13.0).currency("BRL").build();
 
-    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(token, CLIENT_ID, CLIENT_SECRET);
     List<TransactionAddress> transactionAddresses =
         Collections.singletonList(
             new TransactionAddress(
@@ -615,7 +600,6 @@ class IncogniaAPITest {
   @DisplayName("should return an empty response")
   @SneakyThrows
   void testRegisterPayment_whenEvalIsFalse() {
-    String token = TokenCreationFixture.createToken();
     String requestToken = "request-token";
     String accountId = "account-id";
     String externalId = "external-id";
@@ -638,8 +622,6 @@ class IncogniaAPITest {
                     .build())
             .coordinates(new Coordinates(40.74836007062138, -73.98509720487937))
             .build();
-
-    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(token, CLIENT_ID, CLIENT_SECRET);
 
     List<TransactionAddress> transactionAddresses =
         Collections.singletonList(
@@ -691,14 +673,12 @@ class IncogniaAPITest {
   @DisplayName("should be successful")
   @SneakyThrows
   void testRegisterFeedback_whenDataIsValid(boolean dryRun) {
-    String token = TokenCreationFixture.createToken();
     String requestToken = "request-token";
     String accountId = "account-id";
     String externalId = "external-id";
     String signupId = UUID.randomUUID().toString();
     Instant timestamp = Instant.now();
 
-    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(token, CLIENT_ID, CLIENT_SECRET);
     dispatcher.setExpectedFeedbackRequestBody(
         PostFeedbackRequestBody.builder()
             .requestToken(requestToken)
@@ -726,7 +706,6 @@ class IncogniaAPITest {
   @DisplayName("should be successful with expiresAt")
   @SneakyThrows
   void testRegisterFeedback_withExpiresAt(boolean dryRun) {
-    String token = TokenCreationFixture.createToken();
     String requestToken = "request-token";
     String accountId = "account-id";
     String externalId = "external-id";
@@ -734,7 +713,7 @@ class IncogniaAPITest {
     Instant timestamp = Instant.now();
     Instant expiresAt = timestamp.plusSeconds(3600);
 
-    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(token, CLIENT_ID, CLIENT_SECRET);
+    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(CLIENT_ID, CLIENT_SECRET);
     dispatcher.setExpectedFeedbackRequestBody(
         PostFeedbackRequestBody.builder()
             .requestToken(requestToken)

--- a/src/test/java/com/incognia/api/clients/NetworkingClientTest.java
+++ b/src/test/java/com/incognia/api/clients/NetworkingClientTest.java
@@ -9,6 +9,7 @@ import com.incognia.fixtures.TestRequestBody;
 import com.incognia.fixtures.TestResponseBody;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import lombok.SneakyThrows;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.Dispatcher;
@@ -58,7 +59,12 @@ class NetworkingClientTest {
           }
         });
     TestResponseBody response =
-        client.doPost("v2/testurl", new TestRequestBody("id", 123), TestResponseBody.class);
+        client.doPost(
+            "v2/testurl",
+            new TestRequestBody("id", 123),
+            TestResponseBody.class,
+            Collections.emptyMap(),
+            Collections.emptyMap());
     assertThat(response.getName()).isEqualTo("my awesome name");
   }
 
@@ -82,7 +88,12 @@ class NetworkingClientTest {
         });
     assertThatThrownBy(
             () ->
-                client.doPost("v2/testurl", new TestRequestBody("id", 123), TestResponseBody.class))
+                client.doPost(
+                    "v2/testurl",
+                    new TestRequestBody("id", 123),
+                    TestResponseBody.class,
+                    Collections.emptyMap(),
+                    Collections.emptyMap()))
         .satisfies(
             e -> {
               assertThat(e).isInstanceOf(IncogniaAPIException.class);

--- a/src/test/java/com/incognia/api/clients/TokenAwareDispatcher.java
+++ b/src/test/java/com/incognia/api/clients/TokenAwareDispatcher.java
@@ -5,12 +5,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.incognia.feedback.PostFeedbackRequestBody;
 import com.incognia.fixtures.ResourceUtils;
+import com.incognia.fixtures.TokenCreationFixture;
 import com.incognia.onboarding.PostSignupRequestBody;
 import com.incognia.transaction.PostTransactionRequestBody;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
-import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.SneakyThrows;
@@ -29,10 +29,12 @@ public class TokenAwareDispatcher extends Dispatcher {
           System.getProperty("os.version"),
           System.getProperty("os.arch"),
           System.getProperty("java.version"));
-  private final String token;
+  @Setter private static String token = TokenCreationFixture.createToken();
+
   private final String clientId;
   private final String clientSecret;
   private final ObjectMapper objectMapper;
+
   @Setter private String expectedInstallationId;
   @Setter private String expectedExternalId;
   @Setter private String expectedAccountId;
@@ -41,15 +43,12 @@ public class TokenAwareDispatcher extends Dispatcher {
   @Setter private String expectedPolicyId;
   @Setter private String expectedAddressLine;
   @Setter private Map<String, Object> expectedCustomProperties;
-  @Setter private String expectedSessionToken;
   @Setter private String expectedRequestToken;
-  @Setter private UUID expectedSignupId;
   @Setter private PostTransactionRequestBody expectedTransactionRequestBody;
   @Setter private PostFeedbackRequestBody expectedFeedbackRequestBody;
   @Getter private int tokenRequestCount;
 
-  public TokenAwareDispatcher(String token, String clientId, String clientSecret) {
-    this.token = token;
+  public TokenAwareDispatcher(String clientId, String clientSecret) {
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.tokenRequestCount = 0;
@@ -176,7 +175,7 @@ public class TokenAwareDispatcher extends Dispatcher {
           .setBody(
               "{\"access_token\": \""
                   + token
-                  + "\",\"expires_in\": 100,\"token_type\": \"Bearer\"}");
+                  + "\",\"expires_in\": 12,\"token_type\": \"Bearer\"}");
     }
     return new MockResponse().setResponseCode(401);
   }

--- a/src/test/java/com/incognia/api/clients/TokenAwareNetworkingClientTest.java
+++ b/src/test/java/com/incognia/api/clients/TokenAwareNetworkingClientTest.java
@@ -7,7 +7,6 @@ import com.incognia.common.exceptions.IncogniaAPIException;
 import com.incognia.common.exceptions.IncogniaException;
 import com.incognia.fixtures.TestRequestBody;
 import com.incognia.fixtures.TestResponseBody;
-import com.incognia.fixtures.TokenCreationFixture;
 import java.io.IOException;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockWebServer;
@@ -17,8 +16,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class TokenAwareNetworkingClientTest {
-  private static final String CLIENT_ID = "client-id";
-  private static final String CLIENT_SECRET = "client-secret";
+  private final String CLIENT_ID = "client-id";
+  private final String CLIENT_SECRET = "client-secret";
   private TokenAwareNetworkingClient client;
   private MockWebServer mockServer;
 
@@ -37,25 +36,32 @@ class TokenAwareNetworkingClientTest {
 
   @Test
   @DisplayName("should call the api with the same valid token")
-  void testDoPost_whenNoTokenExistsYetAndCredentialsAreValid() throws IncogniaException {
-    String token = TokenCreationFixture.createToken();
-    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(token, CLIENT_ID, CLIENT_SECRET);
+  void testDoPost_whenNoTokenExistsYetAndCredentialsAreValid()
+      throws IncogniaException, InterruptedException {
+
+    synchronized (this) {
+      wait(15000); // Wait for token to expire (15 seconds)
+    }
+
+    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(CLIENT_ID, CLIENT_SECRET);
     mockServer.setDispatcher(dispatcher);
+
     for (int i = 0; i < 2; i++) {
       TestResponseBody testResponseBody =
           client.doPost(
               "api/v2/onboarding", new TestRequestBody("my-id", 1234), TestResponseBody.class);
       assertThat(testResponseBody.getName()).isEqualTo("my awesome name");
     }
+
     assertThat(dispatcher.getTokenRequestCount()).isEqualTo(1);
   }
 
   @Test
   @DisplayName("should get a 401 error")
   void testDoPost_whenNoTokenExistsYetAndCredentialsAreInvalid() {
-    String token = TokenCreationFixture.createToken();
-    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(token, "invalid", CLIENT_SECRET);
+    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher("invalid", CLIENT_SECRET);
     mockServer.setDispatcher(dispatcher);
+
     assertThatThrownBy(
             () ->
                 client.doPost(

--- a/src/test/java/com/incognia/api/clients/TokenProviderTest.java
+++ b/src/test/java/com/incognia/api/clients/TokenProviderTest.java
@@ -1,0 +1,68 @@
+package com.incognia.api.clients;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.incognia.common.exceptions.IncogniaException;
+import java.io.IOException;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TokenProviderTest {
+  private final String CLIENT_ID = "client-id";
+  private final String CLIENT_SECRET = "client-secret";
+  private MockWebServer mockServer;
+  private TokenProvider tokenProvider;
+
+  @BeforeEach
+  void setUp() {
+    mockServer = new MockWebServer();
+    tokenProvider =
+        new TokenProvider(
+            CLIENT_ID,
+            CLIENT_SECRET,
+            new NetworkingClient(new OkHttpClient(), mockServer.url("").toString()));
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    mockServer.shutdown();
+  }
+
+  @Test
+  public void testGetToken_whenTokenIsNotNullAndExpired_shouldUpdateToken()
+      throws IncogniaException, InterruptedException {
+    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(CLIENT_ID, CLIENT_SECRET);
+    mockServer.setDispatcher(dispatcher);
+
+    TokenResponse token = tokenProvider.getToken();
+    assertThat(token).isNotNull();
+
+    synchronized (this) {
+      wait(15000); // Wait for token to expire (15 seconds)
+    }
+
+    tokenProvider.getToken();
+
+    assertThat(dispatcher.getTokenRequestCount()).isEqualTo(2);
+  }
+
+  @Test
+  public void testGetToken_whenTokenIsNotExpired_shouldNotUpdateToken()
+      throws IncogniaException, InterruptedException {
+    synchronized (this) {
+      wait(15000); // Wait for token to expire (15 seconds)
+    }
+    TokenAwareDispatcher dispatcher = new TokenAwareDispatcher(CLIENT_ID, CLIENT_SECRET);
+    mockServer.setDispatcher(dispatcher);
+
+    TokenResponse token = tokenProvider.getToken();
+    assertThat(token).isNotNull();
+
+    tokenProvider.getToken();
+
+    assertThat(dispatcher.getTokenRequestCount()).isEqualTo(1);
+  }
+}


### PR DESCRIPTION
## Proposed changes

As right now the Access Token refresh is a sync operation and not thread safe. Meaning that two threads or more trying to do a request at the same time will invoke the refresh token at the same time refreshing it more than needed. This PRs introduces changes to make the TokenResponse object volatile and lock mechanism since the Token expiration also needs to be change while updating the token.

Since most of the code/test didn't consider such condition it was required more changes to other classes and tests. A refactor was performed so we could have token awareness across threads.

Also, there was some unused code that I took the opportunity to remove.

## Checklist
- [x] Style check and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
