### PR TITLE
Feat/add payment fields

### DIFF
--- a/src/main/java/com/incognia/api/IncogniaAPI.java
+++ b/src/main/java/com/incognia/api/IncogniaAPI.java
@@ -432,6 +432,10 @@ public class IncogniaAPI {
    * @throws IncogniaAPIException in case of api errors
    * @throws IncogniaException in case of unexpected errors
    */
+  // custom properties
+  // location
+  // coupon
+  // related account id
   public TransactionAssessment registerPayment(RegisterPaymentRequest request)
       throws IncogniaException {
     Asserts.assertNotNull(request, "register payment request");
@@ -452,6 +456,10 @@ public class IncogniaAPI {
             .addresses(transactionAddresses)
             .paymentValue(request.getPaymentValue())
             .paymentMethods(request.getPaymentMethods())
+            .location(request.getLocation())
+            .storeId(request.getStoreId())
+            .customProperties(request.getCustomProperties())
+            .coupon(request.getCoupon())
             .build();
 
     Map<String, String> queryParameters = new HashMap<>();

--- a/src/main/java/com/incognia/api/IncogniaAPI.java
+++ b/src/main/java/com/incognia/api/IncogniaAPI.java
@@ -432,10 +432,6 @@ public class IncogniaAPI {
    * @throws IncogniaAPIException in case of api errors
    * @throws IncogniaException in case of unexpected errors
    */
-  // custom properties
-  // location
-  // coupon
-  // related account id
   public TransactionAssessment registerPayment(RegisterPaymentRequest request)
       throws IncogniaException {
     Asserts.assertNotNull(request, "register payment request");

--- a/src/main/java/com/incognia/transaction/PostTransactionRequestBody.java
+++ b/src/main/java/com/incognia/transaction/PostTransactionRequestBody.java
@@ -2,6 +2,7 @@ package com.incognia.transaction;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.incognia.common.Location;
+import com.incognia.transaction.payment.Coupon;
 import com.incognia.transaction.payment.PaymentMethod;
 import com.incognia.transaction.payment.PaymentValue;
 import java.util.Collections;
@@ -21,8 +22,10 @@ public class PostTransactionRequestBody {
   String sessionToken;
   String policyId;
   String type;
+  String storeId;
   String externalId;
   Location location;
+  Coupon coupon;
 
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   @Builder.Default

--- a/src/main/java/com/incognia/transaction/payment/Coupon.java
+++ b/src/main/java/com/incognia/transaction/payment/Coupon.java
@@ -1,0 +1,14 @@
+package com.incognia.transaction.payment;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class Coupon {
+  String type;
+  Double value;
+  Double maxDiscount;
+  String id;
+  String name;
+}

--- a/src/main/java/com/incognia/transaction/payment/RegisterPaymentRequest.java
+++ b/src/main/java/com/incognia/transaction/payment/RegisterPaymentRequest.java
@@ -14,7 +14,7 @@ import lombok.Value;
 
 @Value
 @Builder
-@AllArgsConstructor // ------------------------------- entender o que isso faz
+@AllArgsConstructor
 public class RegisterPaymentRequest {
   String installationId;
   String requestToken;

--- a/src/main/java/com/incognia/transaction/payment/RegisterPaymentRequest.java
+++ b/src/main/java/com/incognia/transaction/payment/RegisterPaymentRequest.java
@@ -1,17 +1,20 @@
 package com.incognia.transaction.payment;
 
 import com.incognia.common.Address;
+import com.incognia.common.Location;
 import com.incognia.transaction.AddressType;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Value;
 
 @Value
 @Builder
+@AllArgsConstructor // ------------------------------- entender o que isso faz
 public class RegisterPaymentRequest {
   String installationId;
   String requestToken;
@@ -20,9 +23,13 @@ public class RegisterPaymentRequest {
   String accountId;
   String externalId;
   String policyId;
+  String storeId;
   @Builder.Default Map<AddressType, Address> addresses = Collections.emptyMap();
   @Builder.Default List<PaymentMethod> paymentMethods = Collections.emptyList();
+  @Builder.Default Map<String, Object> customProperties = Collections.emptyMap();
   PaymentValue paymentValue;
+  Location location;
+  Coupon coupon;
 
   @Getter(AccessLevel.NONE)
   Boolean evaluateTransaction;

--- a/src/test/java/com/incognia/api/IncogniaAPITest.java
+++ b/src/test/java/com/incognia/api/IncogniaAPITest.java
@@ -35,6 +35,7 @@ import com.incognia.transaction.TransactionAssessment;
 import com.incognia.transaction.login.RegisterLoginRequest;
 import com.incognia.transaction.login.RegisterWebLoginRequest;
 import com.incognia.transaction.payment.CardInfo;
+import com.incognia.transaction.payment.Coupon;
 import com.incognia.transaction.payment.PaymentMethod;
 import com.incognia.transaction.payment.PaymentType;
 import com.incognia.transaction.payment.PaymentValue;
@@ -588,6 +589,24 @@ class IncogniaAPITest {
     String deviceOs = "iOS";
     String externalId = "external-id";
     String policyId = "policy-id";
+    String storeId = "store-id";
+    Location location =
+        Location.builder()
+            .latitude("40.74836007062138")
+            .longitude("-73.98509720487937")
+            .collectedAt(Instant.now().toString())
+            .build();
+    Coupon coupon =
+        Coupon.builder()
+            .type("percent_off")
+            .value(10.0)
+            .maxDiscount(5.0)
+            .id("coupon-id")
+            .name("coupon-name")
+            .build();
+    Map<String, Object> customProperties = new HashMap<>();
+    customProperties.put("custom-property", "custom-value");
+    customProperties.put("float-property", 12.345);
     Address address =
         Address.builder()
             .structuredAddress(
@@ -636,6 +655,10 @@ class IncogniaAPITest {
             .evaluateTransaction(eval)
             .paymentValue(paymentValue)
             .paymentMethods(paymentMethods)
+            .storeId(storeId)
+            .coupon(coupon)
+            .customProperties(customProperties)
+            .location(location)
             .build();
     dispatcher.setExpectedTransactionRequestBody(
         PostTransactionRequestBody.builder()
@@ -649,7 +672,10 @@ class IncogniaAPITest {
             .addresses(transactionAddresses)
             .paymentValue(paymentValue)
             .paymentMethods(paymentMethods)
-            .customProperties(null)
+            .storeId(storeId)
+            .coupon(coupon)
+            .customProperties(customProperties)
+            .location(location)
             .build());
     mockServer.setDispatcher(dispatcher);
     TransactionAssessment transactionAssessment = client.registerPayment(paymentRequest);


### PR DESCRIPTION
## Proposed changes

This commit adds the following parameters to the `registerPayment` function:

- `location`
- `store_id`
- `custom_properties`
- `coupon`

## Additional context

The `store_id` parameter is documented in the API reference , but not in the developer docs.
In live API tests, adding this field raises no errors, but I'm unsure if the field is ever processed or just ignored.

## Checklist

- [x] Style check and tests pass locally with my changes, as well as on identical workflow on forked repository
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested the updated request signature works on the live API endpoint