### PR TITLE
feat: adds related_account_id to login requests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.incognia"
-version = "3.8.0"
+version = "3.10.0"
 
 task createProjectVersionFile {
     def projectVersionDir = "$projectDir/src/main/java/com/incognia/api"

--- a/src/main/java/com/incognia/api/IncogniaAPI.java
+++ b/src/main/java/com/incognia/api/IncogniaAPI.java
@@ -250,6 +250,7 @@ public class IncogniaAPI {
             .accountId(request.getAccountId())
             .externalId(request.getExternalId())
             .policyId(request.getPolicyId())
+            .relatedAccountId(request.getRelatedAccountId())
             .customProperties(request.getCustomProperties())
             .type("login")
             .build();

--- a/src/main/java/com/incognia/transaction/PostTransactionRequestBody.java
+++ b/src/main/java/com/incognia/transaction/PostTransactionRequestBody.java
@@ -24,6 +24,7 @@ public class PostTransactionRequestBody {
   String type;
   String storeId;
   String externalId;
+  String relatedAccountId;
   Location location;
   Coupon coupon;
 

--- a/src/main/java/com/incognia/transaction/login/RegisterLoginRequest.java
+++ b/src/main/java/com/incognia/transaction/login/RegisterLoginRequest.java
@@ -17,6 +17,7 @@ public class RegisterLoginRequest {
   String policyId;
   String appVersion;
   String deviceOs;
+  String relatedAccountId;
   Map<String, Object> customProperties;
   Location location;
 

--- a/src/test/java/com/incognia/api/IncogniaAPITest.java
+++ b/src/test/java/com/incognia/api/IncogniaAPITest.java
@@ -475,6 +475,7 @@ class IncogniaAPITest {
     String deviceOs = "Android";
     String externalId = "external-id";
     String policyId = "policy-id";
+    String relatedAccountId = "related-account-id";
     Map<String, Object> map = new HashMap<>();
     map.put("custom-property", "custom-value");
 
@@ -490,6 +491,7 @@ class IncogniaAPITest {
             .addresses(null)
             .paymentMethods(null)
             .policyId(policyId)
+            .relatedAccountId(relatedAccountId)
             .customProperties(map)
             .build());
     mockServer.setDispatcher(dispatcher);
@@ -503,6 +505,7 @@ class IncogniaAPITest {
             .externalId(externalId)
             .evaluateTransaction(eval)
             .policyId(policyId)
+            .relatedAccountId(relatedAccountId)
             .customProperties(map)
             .build();
     TransactionAssessment transactionAssessment = client.registerLogin(loginRequest);


### PR DESCRIPTION
## Proposed changes

Adds `related_account_id` field to the `registerLogin` request

## Checklist
- [x] Style check and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested on the live API