### PR TITLE
Feat/add bank account info

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ And then add the artifact `incognia-api-client` **or** `incognia-api-client-shad
 <dependency>
   <groupId>com.incognia</groupId>
   <artifactId>incognia-api-client</artifactId>
-  <version>3.10.0</version>
+  <version>3.11.0</version>
 </dependency>
 ```
 ```xml
 <dependency>
   <groupId>com.incognia</groupId>
   <artifactId>incognia-api-client-shaded</artifactId>
-  <version>3.10.0</version>
+  <version>3.11.0</version>
 </dependency>
 ```
 
@@ -47,13 +47,13 @@ repositories {
 And then add the dependency
 ```gradle
 dependencies {
-     implementation 'com.incognia:incognia-api-client:3.8.0'
+     implementation 'com.incognia:incognia-api-client:3.11.0'
 }
 ```
 OR
 ```gradle
 dependencies {
-     implementation 'com.incognia:incognia-api-client-shaded:3.8.0'
+     implementation 'com.incognia:incognia-api-client-shaded:3.11.0'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.incognia"
-version = "3.10.0"
+version = "3.11.0"
 
 task createProjectVersionFile {
     def projectVersionDir = "$projectDir/src/main/java/com/incognia/api"

--- a/src/main/java/com/incognia/api/IncogniaAPI.java
+++ b/src/main/java/com/incognia/api/IncogniaAPI.java
@@ -463,6 +463,8 @@ public class IncogniaAPI {
             .customProperties(request.getCustomProperties())
             .coupon(request.getCoupon())
             .personId(request.getPersonId())
+            .debtorAccount(request.getDebtorAccount())
+            .creditorAccount(request.getCreditorAccount())
             .build();
 
     Map<String, String> queryParameters = new HashMap<>();

--- a/src/main/java/com/incognia/transaction/PostTransactionRequestBody.java
+++ b/src/main/java/com/incognia/transaction/PostTransactionRequestBody.java
@@ -3,6 +3,7 @@ package com.incognia.transaction;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.incognia.common.Location;
 import com.incognia.common.PersonID;
+import com.incognia.transaction.payment.BankAccountInfo;
 import com.incognia.transaction.payment.Coupon;
 import com.incognia.transaction.payment.PaymentMethod;
 import com.incognia.transaction.payment.PaymentValue;
@@ -29,6 +30,8 @@ public class PostTransactionRequestBody {
   Location location;
   Coupon coupon;
   PersonID personId;
+  BankAccountInfo debtorAccount;
+  BankAccountInfo creditorAccount;
 
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   @Builder.Default

--- a/src/main/java/com/incognia/transaction/payment/BankAccountInfo.java
+++ b/src/main/java/com/incognia/transaction/payment/BankAccountInfo.java
@@ -1,0 +1,22 @@
+package com.incognia.transaction.payment;
+
+import com.incognia.common.PersonID;
+import java.util.Collections;
+import java.util.List;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class BankAccountInfo {
+  String accountType;
+  String accountPurpose;
+  String holderType;
+  PersonID holderTaxId;
+  String country;
+  String ispbCode;
+  String branchCode;
+  String accountNumber;
+  String accountCheckDigit;
+  @Builder.Default List<PixKey> pixKeys = Collections.emptyList();
+}

--- a/src/main/java/com/incognia/transaction/payment/PixKey.java
+++ b/src/main/java/com/incognia/transaction/payment/PixKey.java
@@ -1,0 +1,11 @@
+package com.incognia.transaction.payment;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class PixKey {
+  String type;
+  String value;
+}

--- a/src/main/java/com/incognia/transaction/payment/RegisterPaymentRequest.java
+++ b/src/main/java/com/incognia/transaction/payment/RegisterPaymentRequest.java
@@ -32,6 +32,8 @@ public class RegisterPaymentRequest {
   Location location;
   Coupon coupon;
   PersonID personId;
+  BankAccountInfo debtorAccount;
+  BankAccountInfo creditorAccount;
 
   @Getter(AccessLevel.NONE)
   Boolean evaluateTransaction;

--- a/src/test/java/com/incognia/api/IncogniaAPITest.java
+++ b/src/test/java/com/incognia/api/IncogniaAPITest.java
@@ -35,11 +35,13 @@ import com.incognia.transaction.TransactionAddress;
 import com.incognia.transaction.TransactionAssessment;
 import com.incognia.transaction.login.RegisterLoginRequest;
 import com.incognia.transaction.login.RegisterWebLoginRequest;
+import com.incognia.transaction.payment.BankAccountInfo;
 import com.incognia.transaction.payment.CardInfo;
 import com.incognia.transaction.payment.Coupon;
 import com.incognia.transaction.payment.PaymentMethod;
 import com.incognia.transaction.payment.PaymentType;
 import com.incognia.transaction.payment.PaymentValue;
+import com.incognia.transaction.payment.PixKey;
 import com.incognia.transaction.payment.RegisterPaymentRequest;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -664,6 +666,24 @@ class IncogniaAPITest {
         Collections.singletonList(
             new TransactionAddress(
                 "shipping", null, address.getStructuredAddress(), address.getCoordinates()));
+
+    List<PixKey> pixKeys = new ArrayList<>();
+    pixKeys.add(PixKey.builder().type("cpf").value("12345678901").build());
+
+    BankAccountInfo bankAccount =
+        BankAccountInfo.builder()
+            .accountType("checking")
+            .accountPurpose("general")
+            .holderType("individual")
+            .holderTaxId(PersonID.builder().type("cpf").value("12345678901").build())
+            .country("BR")
+            .ispbCode("12345678")
+            .branchCode("0000")
+            .accountNumber("123456")
+            .accountCheckDigit("0")
+            .pixKeys(pixKeys)
+            .build();
+
     RegisterPaymentRequest paymentRequest =
         RegisterPaymentRequest.builder()
             .requestToken(requestToken)
@@ -681,6 +701,8 @@ class IncogniaAPITest {
             .customProperties(customProperties)
             .location(location)
             .personId(personId)
+            .debtorAccount(bankAccount)
+            .creditorAccount(bankAccount)
             .build();
     dispatcher.setExpectedTransactionRequestBody(
         PostTransactionRequestBody.builder()
@@ -699,6 +721,8 @@ class IncogniaAPITest {
             .customProperties(customProperties)
             .location(location)
             .personId(personId)
+            .debtorAccount(bankAccount)
+            .creditorAccount(bankAccount)
             .build());
     mockServer.setDispatcher(dispatcher);
     TransactionAssessment transactionAssessment = client.registerPayment(paymentRequest);


### PR DESCRIPTION
## Proposed changes

Adds `debtorAccount` and `creditorAccount` fields to the `registerPayment` method

## Checklist
- [x] Style check and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested on the live API endpoint